### PR TITLE
Add namespace schemas: phip:mechanical, phip:datacenter, phip:software, phip:compliance

### DIFF
--- a/schemas/compliance.json
+++ b/schemas/compliance.json
@@ -1,0 +1,120 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/mfgs-us/phip/schemas/compliance.json",
+  "title": "phip:compliance",
+  "description": "Schema for the phip:compliance attribute namespace. Covers the condition layer (Section 9.4), certifications, life limits, and chain of custody metadata. Applicable to all object types on the manufacturing track.",
+
+  "type": "object",
+  "properties": {
+    "condition": {
+      "type": "string",
+      "description": "Fitness-for-purpose assessment, orthogonal to lifecycle state. An object can be 'deployed' but 'condemned', or 'stock' but 'degraded'.",
+      "enum": ["serviceable", "degraded", "condemned", "quarantined"]
+    },
+    "condition_reason": {
+      "type": "string",
+      "description": "Human-readable reason for the current condition (e.g. 'temperature_exceedance', 'impact_damage', 'scheduled_inspection')."
+    },
+    "condition_set_by": {
+      "type": "string",
+      "description": "PhIP URI of the actor who set the condition.",
+      "pattern": "^phip://[A-Za-z0-9.-]+/[A-Za-z0-9._~%-]+(?:/[A-Za-z0-9._~%-]+)+$"
+    },
+    "condition_timestamp": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 timestamp of when the condition was assessed."
+    },
+    "certifications": {
+      "type": "array",
+      "description": "List of certifications or regulatory approvals held by this object.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "standard": {
+            "type": "string",
+            "description": "Certification standard (e.g. 'ISO 9001', 'UL 60950', 'FAA PMA', 'CE')."
+          },
+          "certificate_id": {
+            "type": "string",
+            "description": "Certificate or approval number."
+          },
+          "issued_by": {
+            "type": "string",
+            "description": "Certifying body name."
+          },
+          "issued_date": {
+            "type": "string",
+            "format": "date",
+            "description": "Date the certification was issued."
+          },
+          "expires_date": {
+            "type": "string",
+            "format": "date",
+            "description": "Date the certification expires, if applicable."
+          },
+          "status": {
+            "type": "string",
+            "enum": ["valid", "expired", "revoked", "suspended"]
+          }
+        },
+        "required": ["standard"]
+      }
+    },
+    "life_limit_hours": {
+      "type": "number",
+      "description": "Maximum operational hours before mandatory replacement or overhaul.",
+      "exclusiveMinimum": 0
+    },
+    "life_limit_cycles": {
+      "type": "integer",
+      "description": "Maximum operational cycles (e.g. pressurization cycles, thermal cycles) before mandatory action.",
+      "exclusiveMinimum": 0
+    },
+    "hours_since_new": {
+      "type": "number",
+      "description": "Total operational hours accumulated since manufacture.",
+      "minimum": 0
+    },
+    "cycles_since_new": {
+      "type": "integer",
+      "description": "Total operational cycles accumulated since manufacture.",
+      "minimum": 0
+    },
+    "hours_since_overhaul": {
+      "type": "number",
+      "description": "Operational hours accumulated since last overhaul.",
+      "minimum": 0
+    },
+    "next_inspection_date": {
+      "type": "string",
+      "format": "date",
+      "description": "Date of next scheduled inspection or maintenance action."
+    },
+    "chain_of_custody": {
+      "type": "array",
+      "description": "Ordered list of custodians this object has passed through. Informational — the authoritative chain is derived from the event history.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "custodian": {
+            "type": "string",
+            "description": "PhIP URI or name of the custodian."
+          },
+          "from": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Start of custody period."
+          },
+          "to": {
+            "type": "string",
+            "format": "date-time",
+            "description": "End of custody period. Null or absent if current."
+          }
+        },
+        "required": ["custodian", "from"]
+      }
+    }
+  },
+  "additionalProperties": true
+}

--- a/schemas/datacenter.json
+++ b/schemas/datacenter.json
@@ -1,0 +1,84 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/mfgs-us/phip/schemas/datacenter.json",
+  "title": "phip:datacenter",
+  "description": "Schema for the phip:datacenter attribute namespace. Covers rack-mount positioning, power, thermal, and network port inventory. Applicable to object types: component, assembly, system, location.",
+
+  "type": "object",
+  "properties": {
+    "rack_units": {
+      "type": "integer",
+      "description": "Height in standard rack units (1U = 44.45 mm).",
+      "minimum": 1
+    },
+    "rack_position": {
+      "type": "integer",
+      "description": "Starting rack unit position (bottom of device), numbered from 1 at the bottom of the rack.",
+      "minimum": 1
+    },
+    "rack_side": {
+      "type": "string",
+      "description": "Which side of the rack the device faces.",
+      "enum": ["front", "rear"]
+    },
+    "power_draw_watts": {
+      "type": "number",
+      "description": "Rated or measured power draw in watts.",
+      "minimum": 0
+    },
+    "power_supply_count": {
+      "type": "integer",
+      "description": "Number of installed power supply units.",
+      "minimum": 0
+    },
+    "power_supply_redundancy": {
+      "type": "string",
+      "description": "Power supply redundancy configuration.",
+      "enum": ["none", "n+1", "2n"]
+    },
+    "thermal_design_power_watts": {
+      "type": "number",
+      "description": "Thermal design power (TDP) in watts — maximum heat dissipation.",
+      "minimum": 0
+    },
+    "cooling": {
+      "type": "string",
+      "description": "Cooling method.",
+      "enum": ["air", "liquid", "immersion", "passive"]
+    },
+    "inlet_temp_max_c": {
+      "type": "number",
+      "description": "Maximum rated inlet air temperature in degrees Celsius."
+    },
+    "network_ports": {
+      "type": "array",
+      "description": "Inventory of network ports on this device.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Port label (e.g. 'eth0', 'mgmt', 'bmc')."
+          },
+          "speed_gbps": {
+            "type": "number",
+            "description": "Rated link speed in Gbps.",
+            "minimum": 0
+          },
+          "media": {
+            "type": "string",
+            "description": "Physical media type.",
+            "enum": ["copper", "fiber_sm", "fiber_mm", "dac", "aoc"]
+          },
+          "connector": {
+            "type": "string",
+            "description": "Connector form factor.",
+            "enum": ["rj45", "sfp", "sfp+", "sfp28", "qsfp+", "qsfp28", "qsfp-dd", "osfp"]
+          }
+        },
+        "required": ["name"]
+      }
+    }
+  },
+  "additionalProperties": true
+}

--- a/schemas/mechanical.json
+++ b/schemas/mechanical.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/mfgs-us/phip/schemas/mechanical.json",
+  "title": "phip:mechanical",
+  "description": "Schema for the phip:mechanical attribute namespace. Covers physical dimensions, weight, material composition, and dimensional tolerances. Applicable to object types: material, component, assembly, system.",
+
+  "type": "object",
+  "properties": {
+    "length_mm": {
+      "type": "number",
+      "description": "Length in millimeters.",
+      "exclusiveMinimum": 0
+    },
+    "width_mm": {
+      "type": "number",
+      "description": "Width in millimeters.",
+      "exclusiveMinimum": 0
+    },
+    "height_mm": {
+      "type": "number",
+      "description": "Height in millimeters.",
+      "exclusiveMinimum": 0
+    },
+    "weight_kg": {
+      "type": "number",
+      "description": "Weight in kilograms.",
+      "exclusiveMinimum": 0
+    },
+    "material": {
+      "type": "string",
+      "description": "Primary material name or alloy designation (e.g. '6061-T6', 'FR-4', 'AISI 304')."
+    },
+    "material_class": {
+      "type": "string",
+      "description": "Broad material classification.",
+      "enum": [
+        "metal",
+        "polymer",
+        "ceramic",
+        "composite",
+        "semiconductor",
+        "glass",
+        "organic",
+        "other"
+      ]
+    },
+    "finish": {
+      "type": "string",
+      "description": "Surface finish or coating (e.g. 'anodized', 'powder-coat', 'bare')."
+    },
+    "color": {
+      "type": "string",
+      "description": "Human-readable color name or hex code."
+    },
+    "tolerances": {
+      "type": "object",
+      "description": "Dimensional tolerances keyed by dimension name.",
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "nominal_mm": { "type": "number" },
+          "upper_mm": { "type": "number" },
+          "lower_mm": { "type": "number" }
+        },
+        "required": ["nominal_mm"]
+      }
+    }
+  },
+  "additionalProperties": true
+}

--- a/schemas/software.json
+++ b/schemas/software.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/mfgs-us/phip/schemas/software.json",
+  "title": "phip:software",
+  "description": "Schema for the phip:software attribute namespace. Covers firmware and software versions, configuration hashes, and OS identity. Applicable to object types: component, assembly, system.",
+
+  "type": "object",
+  "properties": {
+    "firmware": {
+      "type": "string",
+      "description": "Firmware version identifier (e.g. 'droyd-fw-2.1.4')."
+    },
+    "firmware_date": {
+      "type": "string",
+      "format": "date",
+      "description": "Firmware build or release date (ISO 8601 date)."
+    },
+    "bios_version": {
+      "type": "string",
+      "description": "BIOS or UEFI version identifier."
+    },
+    "bmc_version": {
+      "type": "string",
+      "description": "Baseboard management controller firmware version."
+    },
+    "os": {
+      "type": "string",
+      "description": "Operating system name and version (e.g. 'Ubuntu 24.04 LTS', 'VxWorks 7')."
+    },
+    "kernel": {
+      "type": "string",
+      "description": "Kernel version string."
+    },
+    "config_hash": {
+      "type": "string",
+      "description": "Hash of the active configuration, for drift detection. Format: 'sha256:<hex>' or 'sha512:<hex>'.",
+      "pattern": "^(sha256|sha512):[0-9a-f]+$"
+    },
+    "image_hash": {
+      "type": "string",
+      "description": "Hash of the deployed firmware or OS image.",
+      "pattern": "^(sha256|sha512):[0-9a-f]+$"
+    },
+    "bootloader": {
+      "type": "string",
+      "description": "Bootloader identifier and version."
+    },
+    "drivers": {
+      "type": "object",
+      "description": "Driver versions keyed by driver name or subsystem.",
+      "additionalProperties": {
+        "type": "string"
+      }
+    }
+  },
+  "additionalProperties": true
+}

--- a/spec/CHANGELOG.md
+++ b/spec/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to the PhIP specification will be documented in this file.
 ## [0.1.0-draft] — 2026-04-09
 
 ### Added
+- Four namespace schemas: `phip:mechanical` (dimensions, weight, material, 
+  tolerances), `phip:datacenter` (rack position, power, thermal, network 
+  ports), `phip:software` (firmware, config hashes, OS, drivers), and 
+  `phip:compliance` (condition layer, certifications, life limits, chain 
+  of custody). Validated against 27 test cases.
 - Initial draft of PhIP Core Specification
 - URI scheme definition (Section 4)
 - Object model with four required fields (Section 5)

--- a/spec/phip-core.md
+++ b/spec/phip-core.md
@@ -421,11 +421,11 @@ namespace. This is the primary extensibility mechanism.
 
 | Namespace | Description | Status |
 |---|---|---|
-| `phip:mechanical` | Dimensions, weight, material, tolerances | [TODO] |
+| `phip:mechanical` | Dimensions, weight, material, tolerances | Defined — `schemas/mechanical.json` |
 | `phip:electrical` | Voltage, current, connector types | [TODO] |
-| `phip:software` | Firmware, software versions, config hashes | [TODO] |
-| `phip:datacenter` | Rack position, power, thermal | [TODO] |
-| `phip:compliance` | Certifications, life limits, chain of custody | [TODO] |
+| `phip:software` | Firmware, software versions, config hashes | Defined — `schemas/software.json` |
+| `phip:datacenter` | Rack position, power, thermal | Defined — `schemas/datacenter.json` |
+| `phip:compliance` | Certifications, life limits, chain of custody | Defined — `schemas/compliance.json` |
 | `phip:procurement` | PO number, supplier, lead time | [TODO] |
 
 ### 8.3 Custom Namespaces


### PR DESCRIPTION
## Summary

Four `phip:` namespace schemas defining content validation for domain-specific attributes within the PhIP object model. These are the first namespace schemas beyond `phip:core`, filling the `[TODO]` markers in Section 8.2 of the spec.

- **`phip:mechanical`** (`schemas/mechanical.json`) — dimensions (mm), weight (kg), material/alloy designation, material class enum (metal, polymer, ceramic, composite, semiconductor, glass, organic), surface finish, color, dimensional tolerances with nominal/upper/lower bounds
- **`phip:datacenter`** (`schemas/datacenter.json`) — rack units, rack position, power draw, PSU count and redundancy config (none/n+1/2n), thermal design power, cooling method (air/liquid/immersion/passive), inlet temp, network port inventory with speed/media/connector enums
- **`phip:software`** (`schemas/software.json`) — firmware version and date, BIOS, BMC, OS, kernel, bootloader, config and image hashes (sha256/sha512 enforced by pattern), driver version map
- **`phip:compliance`** (`schemas/compliance.json`) — condition layer from Section 9.4 (serviceable/degraded/condemned/quarantined), certifications array with standard/status/dates, life limits (hours and cycles), hours/cycles since new and since overhaul, next inspection date, chain of custody records

All schemas use `additionalProperties: true` for forward compatibility. Section 8.2 of the spec is updated to mark these four namespaces as defined.

## Test plan
- [x] All 4 schemas compile under ajv draft-2020-12
- [x] 27 test cases covering spec examples, full profiles, required field enforcement, enum boundaries, pattern matching, and rejection of invalid inputs
- [x] Existing core.json tests (21) and resolver smoke tests (33) still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)