### PR TITLE
Spec v0.1: clear all 22 open issues + add interop test suite

### DIFF
--- a/schemas/access.json
+++ b/schemas/access.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/mfgs-us/phip/schemas/access.json",
+  "version": "1.0",
   "title": "phip:access",
   "description": "Schema for the phip:access attribute namespace. Declares the object's read access policy per Section 11.5. Absence of phip:access on an object is equivalent to policy='public'.",
 

--- a/schemas/access.json
+++ b/schemas/access.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/mfgs-us/phip/schemas/access.json",
+  "title": "phip:access",
+  "description": "Schema for the phip:access attribute namespace. Declares the object's read access policy per Section 11.5. Absence of phip:access on an object is equivalent to policy='public'.",
+
+  "type": "object",
+  "properties": {
+    "policy": {
+      "type": "string",
+      "enum": ["public", "authenticated", "capability", "private"],
+      "description": "Read access policy. 'public' is the default when phip:access is absent. 'authenticated' requires any valid read capability token. 'capability' requires a token whose granted_to matches the requesting actor. 'private' restricts reads to the authority itself."
+    },
+    "policy_set_by": {
+      "type": "string",
+      "description": "PhIP URI of the actor who set the current policy. Informational only — the authoritative record is the event history.",
+      "pattern": "^phip://[A-Za-z0-9.-]+/[A-Za-z0-9._~%-]+(?:/[A-Za-z0-9._~%-]+)+$"
+    },
+    "policy_set_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 timestamp when the current policy was applied."
+    },
+    "rationale": {
+      "type": "string",
+      "description": "Optional human-readable note explaining why the policy was set (e.g. 'contains customer BOM under NDA', 'public regulatory disclosure')."
+    }
+  },
+  "required": ["policy"],
+  "additionalProperties": true
+}

--- a/schemas/compliance.json
+++ b/schemas/compliance.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/mfgs-us/phip/schemas/compliance.json",
+  "version": "1.0",
   "title": "phip:compliance",
   "description": "Schema for the phip:compliance attribute namespace. Covers the condition layer (Section 9.4), certifications, life limits, and chain of custody metadata. Applicable to all object types on the manufacturing track.",
 

--- a/schemas/compliance.json
+++ b/schemas/compliance.json
@@ -56,9 +56,42 @@
           "status": {
             "type": "string",
             "enum": ["valid", "expired", "revoked", "suspended"]
+          },
+          "jurisdiction": {
+            "type": "string",
+            "description": "Regulatory jurisdiction in which the certification is recognized. ISO 3166-1 alpha-2 country code (e.g. 'US', 'DE'), ISO 3166-2 subdivision code (e.g. 'US-CA'), or a recognized supranational code ('EU', 'UNECE'). Use 'GLOBAL' for worldwide-recognized certifications."
+          },
+          "regulatory_authority": {
+            "type": "string",
+            "description": "Name or PhIP URI of the regulatory body whose authority is invoked (e.g. 'FAA', 'FDA', 'EASA', 'phip://faa.gov/agency')."
           }
         },
         "required": ["standard"]
+      }
+    },
+    "applicable_jurisdictions": {
+      "type": "array",
+      "description": "Jurisdictions in which this object MAY be deployed, sold, or operated under its current certifications. Useful for regulated goods (medical devices, aircraft parts, food) where deployment outside the listed jurisdictions is non-compliant.",
+      "items": {
+        "type": "string"
+      }
+    },
+    "export_control": {
+      "type": "object",
+      "description": "Export control classification, if applicable.",
+      "properties": {
+        "regime": {
+          "type": "string",
+          "description": "Export control regime (e.g. 'EAR', 'ITAR', 'EU dual-use')."
+        },
+        "classification": {
+          "type": "string",
+          "description": "Classification code under that regime (e.g. 'EAR99', 'ECCN 5A002', 'ITAR cat. XII')."
+        },
+        "license_number": {
+          "type": "string",
+          "description": "Issued export license number, if any."
+        }
       }
     },
     "life_limit_hours": {

--- a/schemas/core.json
+++ b/schemas/core.json
@@ -26,12 +26,12 @@
 
   "allOf": [
     {
-      "description": "Manufacturing track: material, component, assembly, system, lot use the manufacturing-track state vocabulary.",
+      "description": "Manufacturing track: material, component, assembly, system, lot, design use the manufacturing-track state vocabulary.",
       "if": {
         "required": ["object_type"],
         "properties": {
           "object_type": {
-            "enum": ["material", "component", "assembly", "system", "lot"]
+            "enum": ["material", "component", "assembly", "system", "lot", "design"]
           }
         }
       },
@@ -78,13 +78,14 @@
         "location",
         "vehicle",
         "lot",
-        "actor"
+        "actor",
+        "design"
       ]
     },
 
     "manufacturingState": {
       "type": "string",
-      "description": "States for the manufacturing lifecycle track. Used by material, component, assembly, system, and lot. 'consumed' and 'disposed' are terminal.",
+      "description": "States for the manufacturing lifecycle track. Used by material, component, assembly, system, lot, and design. 'consumed' and 'disposed' are terminal.",
       "enum": [
         "concept",
         "design",
@@ -183,6 +184,8 @@
             "replaces",
             "replaced_by",
             "instance_of",
+            "supersedes",
+            "superseded_by",
             "manufactured_by"
           ]
         },
@@ -487,7 +490,8 @@
         "process",
         "lot_split",
         "lot_merge",
-        "note"
+        "note",
+        "authority_transfer"
       ]
     },
 

--- a/schemas/core.json
+++ b/schemas/core.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/mfgs-us/phip/schemas/core.json",
+  "version": "1.0",
   "title": "PhIP Core Object",
   "description": "JSON Schema for a PhIP (Physical Information Protocol) Object as defined in PhIP Core Specification v0.1.0-draft. Validates object model structure, lifecycle state vocabularies (per object type), relation vocabulary, and event log structure. Cross-event constraints — hash chain continuity, lifecycle transition validity across history, signature cryptographic verification, capability token verification — are resolver-enforced and outside the scope of this schema.",
 

--- a/schemas/datacenter.json
+++ b/schemas/datacenter.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/mfgs-us/phip/schemas/datacenter.json",
+  "version": "1.0",
   "title": "phip:datacenter",
   "description": "Schema for the phip:datacenter attribute namespace. Covers rack-mount positioning, power, thermal, and network port inventory. Applicable to object types: component, assembly, system, location.",
 

--- a/schemas/geo.json
+++ b/schemas/geo.json
@@ -1,0 +1,109 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/mfgs-us/phip/schemas/geo.json",
+  "title": "phip:geo",
+  "description": "Schema for the phip:geo attribute namespace. Carries geographic position, address, and route information for vehicles and mobile locations. Position values are points-in-time snapshots; the authoritative position trajectory is reconstructed from the event history of attribute_update events on the object.",
+
+  "type": "object",
+  "properties": {
+    "position": {
+      "type": "object",
+      "description": "Current geographic position as a single point.",
+      "properties": {
+        "lat": {
+          "type": "number",
+          "minimum": -90,
+          "maximum": 90,
+          "description": "Latitude in decimal degrees, WGS 84."
+        },
+        "lon": {
+          "type": "number",
+          "minimum": -180,
+          "maximum": 180,
+          "description": "Longitude in decimal degrees, WGS 84."
+        },
+        "altitude_m": {
+          "type": "number",
+          "description": "Altitude in metres above WGS 84 ellipsoid."
+        },
+        "accuracy_m": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Estimated horizontal accuracy radius in metres (1-sigma)."
+        },
+        "as_of": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO 8601 timestamp the position was observed."
+        },
+        "source": {
+          "type": "string",
+          "description": "How the position was determined (e.g. 'gps', 'cell_triangulation', 'manual_entry', 'ais', 'ads-b')."
+        }
+      },
+      "required": ["lat", "lon"]
+    },
+    "address": {
+      "type": "object",
+      "description": "Postal or facility address. Used for fixed locations or as a coarse position annotation.",
+      "properties": {
+        "street": { "type": "string" },
+        "locality": { "type": "string", "description": "City or town." },
+        "region": { "type": "string", "description": "State, province, or other subdivision." },
+        "postal_code": { "type": "string" },
+        "country": { "type": "string", "description": "ISO 3166-1 alpha-2 code." }
+      }
+    },
+    "route": {
+      "type": "object",
+      "description": "Planned or active route. Vehicles in transit MAY publish their route for downstream visibility.",
+      "properties": {
+        "origin": {
+          "type": "string",
+          "description": "PhIP URI or human-readable origin."
+        },
+        "destination": {
+          "type": "string",
+          "description": "PhIP URI or human-readable destination."
+        },
+        "waypoints": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "lat": { "type": "number" },
+              "lon": { "type": "number" },
+              "label": { "type": "string" },
+              "eta": { "type": "string", "format": "date-time" }
+            }
+          }
+        },
+        "carrier": {
+          "type": "string",
+          "description": "PhIP URI of the carrier actor (shipping line, trucking company, courier).",
+          "pattern": "^phip://[A-Za-z0-9.-]+/[A-Za-z0-9._~%-]+(?:/[A-Za-z0-9._~%-]+)+$"
+        }
+      }
+    },
+    "geofence": {
+      "type": "object",
+      "description": "Optional geofence for fixed locations or campus-scale facilities.",
+      "properties": {
+        "center": {
+          "type": "object",
+          "properties": {
+            "lat": { "type": "number" },
+            "lon": { "type": "number" }
+          },
+          "required": ["lat", "lon"]
+        },
+        "radius_m": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Radius in metres for a circular geofence."
+        }
+      }
+    }
+  },
+  "additionalProperties": true
+}

--- a/schemas/geo.json
+++ b/schemas/geo.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/mfgs-us/phip/schemas/geo.json",
+  "version": "1.0",
   "title": "phip:geo",
   "description": "Schema for the phip:geo attribute namespace. Carries geographic position, address, and route information for vehicles and mobile locations. Position values are points-in-time snapshots; the authoritative position trajectory is reconstructed from the event history of attribute_update events on the object.",
 

--- a/schemas/mechanical.json
+++ b/schemas/mechanical.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/mfgs-us/phip/schemas/mechanical.json",
+  "version": "1.0",
   "title": "phip:mechanical",
   "description": "Schema for the phip:mechanical attribute namespace. Covers physical dimensions, weight, material composition, and dimensional tolerances. Applicable to object types: material, component, assembly, system.",
 

--- a/schemas/software.json
+++ b/schemas/software.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/mfgs-us/phip/schemas/software.json",
+  "version": "1.0",
   "title": "phip:software",
   "description": "Schema for the phip:software attribute namespace. Covers firmware and software versions, configuration hashes, and OS identity. Applicable to object types: component, assembly, system.",
 

--- a/spec/CHANGELOG.md
+++ b/spec/CHANGELOG.md
@@ -107,6 +107,33 @@ All notable changes to the PhIP specification will be documented in this file.
   4.3.3 plus new Section 12.6 metadata document. Section 13 conformance 
   suite TODO replaced with pointer to `tests/vectors/` and 
   `tests/conformance/`. 19 issues resolved total, 22 deferred.
+- **All five remaining Low-severity issues resolved** — 41 issues 
+  resolved total, 0 deferred. Spec backlog clean for v0.1.0-draft:
+  - **A33: Batch operations** — new §12.5: non-atomic 
+    `/objects/{ns}/batch` and `/push/{ns}/batch`, 1000-event cap, 
+    per-event results, 207 Multi-Status on partial success.
+  - **A34: Offline / air-gapped resolution** — new §4.3.4: warm 
+    cache and signed PhIP bundle format (`manifest.json` + 
+    `objects/`, `history/`, `keys/`), full chain verification on 
+    import, replay-on-reconnect for buffered writes.
+  - **A35: HTTP authentication** — new §12.8: 
+    `Authorization: PhIP-Capability` is the only protocol-level 
+    auth scheme; mTLS is a transport overlay; non-protocol 
+    endpoints (admin, health) free to use any scheme; 
+    basic/bearer/API-key MUST NOT route restricted reads or writes.
+  - **A36: Conformance levels** — §13 restructured into Full / 
+    Read-Only / Mirror / Client-Only classes. New 
+    `WRITE_NOT_SUPPORTED` (405) error code. New `conformance_class` 
+    field in `/meta`.
+  - **A37: Schema versioning** — new §8.4: semver MAJOR.MINOR with 
+    explicit additive vs. breaking change rules, versioned `$id` 
+    URLs, all v0.1 schemas seeded with `version: "1.0"`. 12-month 
+    minimum compatibility window after a MAJOR bump.
+
+- Section 12 sub-numbering: 12.5 (was Error Responses) → 12.6, 12.6 
+  (was Metadata Document) → 12.7, plus new 12.5 Batch Operations and 
+  new 12.8 HTTP Authentication. All cross-references updated.
+
 - **All twelve remaining Medium-severity issues resolved** — 36 issues 
   resolved total, 5 deferred (12 Medium → 0 Medium, all remaining are 
   Low):

--- a/spec/CHANGELOG.md
+++ b/spec/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to the PhIP specification will be documented in this file.
 ## [0.1.0-draft] — 2026-04-09
 
 ### Added
+- Interop prerequisites for multi-language client libraries (`phip-js`, 
+  `phip-py`, etc.): language-agnostic test vectors in `tests/vectors/` 
+  covering JCS canonicalization, SHA-256 event hashing, Ed25519 signing 
+  and verification, URI parsing, hash-chain continuity, lifecycle 
+  transitions, and the self-signed bootstrap key pattern; HTTP black-box 
+  conformance suite in `tests/conformance/` for PhIP servers.
+- Section 4.3 resolver discovery, caching, and redirect policy: authority 
+  name is the resolver identity (no DNS TXT/SRV lookups), `ETag`/
+  `Cache-Control` guidance with tight `max-age` for active objects and 
+  long `max-age` for terminal states, same-authority-only redirect 
+  constraint, and `POST`-preserving redirect rules.
+- Section 12.6 `/.well-known/phip/meta` capability document for resolver 
+  self-description (protocol version, namespaces, supported operations, 
+  schema namespaces). Resolver publication is optional.
 - Four namespace schemas: `phip:mechanical` (dimensions, weight, material, 
   tolerances), `phip:datacenter` (rack position, power, thermal, network 
   ports), `phip:software` (firmware, config hashes, OS, drivers), and 
@@ -89,3 +103,80 @@ All notable changes to the PhIP specification will be documented in this file.
   handling, capability token scopes, pagination, error responses
 - All reference implementation blockers resolved — 18 total issues resolved, 
   23 deferred to post-v0.1
+- **A10: Resolver discovery, caching, redirects** — Section 4.3.1 through 
+  4.3.3 plus new Section 12.6 metadata document. Section 13 conformance 
+  suite TODO replaced with pointer to `tests/vectors/` and 
+  `tests/conformance/`. 19 issues resolved total, 22 deferred.
+- **All twelve remaining Medium-severity issues resolved** — 36 issues 
+  resolved total, 5 deferred (12 Medium → 0 Medium, all remaining are 
+  Low):
+  - **A2: Yield fraction math** — non-negative real values in [0,1]; 
+    sum-per-input ≤ 1 + ε with ε = 1e-6; missing fractions are 
+    "unknown" not implicit-equal-share; numeric representation 
+    guidance. New §10.4.1, §10.4.2.
+  - **A3: Geographic position** — new `phip:geo` namespace covering 
+    WGS 84 position (lat/lon/altitude/accuracy/source), address, 
+    route with waypoints/carrier, and geofence. New 
+    `schemas/geo.json`.
+  - **A4: Multi-party custody transfer** — new §11.3.7 specifying the 
+    prior-custodian → carrier → next-custodian token chain with 
+    pickup/transit/delivery roles, disruption handling, and 
+    sub-delegation rules.
+  - **A5: Lot split mass conservation** — new §10.5.1: 
+    `sum(resulting) ≤ source + ε` with optional `loss_quantity`; 
+    `lot_merge` enforces equality; unit-mismatched merges require a 
+    `process` event.
+  - **A6: Measurement payload** — new §11.4.2 normative shape: 
+    `metric`/`value`/`unit`/`as_of`/`method`/`uncertainty`/
+    `thresholds`/`outcome`/`external_ref`/`samples`. Derived-vs-raw 
+    distinction preserved through history.
+  - **A12: Authority delegation** — new §4.5.1–4.5.5: 
+    `delegations` array in `/meta`, scoped ops, revocation via 
+    metadata edit, depth-limited sub-delegation.
+  - **A14: Lot fungibility** — new §6.4: required `fungible` boolean 
+    on lot identity; non-fungible lots MUST `contains` member items.
+  - **A15: Lot quantity tracking** — new §6.4.1: 
+    `identity.quantity` (`value`/`unit`/`as_of`/`precision`); 
+    partial draw-down via `attribute_update`; split reserved for 
+    new sub-lots.
+  - **A16: Regulatory jurisdiction** — added `jurisdiction`, 
+    `regulatory_authority`, `applicable_jurisdictions`, and 
+    `export_control` to `phip:compliance` schema.
+  - **A18: Uncertainty qualifiers** — new §5.2.1: parallel 
+    `<field>_quality` convention with `confidence`/`source`/`as_of`/
+    `corrected_from`/`note`. Tools MUST treat qualified and 
+    unqualified fields identically for matching.
+  - **A29: connected_to bidirectional cross-org** — new §7.3: 
+    relations are owned by the writing object; cross-authority 
+    inverses are not required; asymmetric relations are not proof 
+    of physical state.
+  - **A30: Dangling relations** — new §7.4: graceful-degradation 
+    rules; new `DANGLING_RELATION` (422) error for same-authority 
+    broken refs; cross-authority targets verified lazily by readers.
+
+- **All five remaining High-severity issues resolved** — 24 issues 
+  resolved total, 17 deferred (5 High → 0 High):
+  - **A26: Read access control** — `phip:access` namespace 
+    (`public`/`authenticated`/`capability`/`private`); capability tokens 
+    gain `read_state`, `read_history`, `read_query` scopes; new 
+    `ACCESS_DENIED` (403) error code; QUERY silently omits inaccessible 
+    objects. New Section 11.5; new `schemas/access.json`.
+  - **A27: Privacy / GDPR annex** — new Section 15 (Privacy 
+    Considerations). No-raw-PII rule, `phip:personal_data` salted-
+    commitment convention, `phip:external_record` for off-chain 
+    references, salt deletion as the erasure mechanism, pseudonymous-
+    actor pattern. IANA renumbered to Section 16, References to 17.
+  - **A1: Sub-object addressing** — Section 4.4 expanded with 4.4.1 
+    (when to register), 4.4.2 (no lifecycle inheritance), 4.4.3 (paths 
+    are informational; `contained_in` is normative).
+  - **A13: Design revision model** — new `design` object type on the 
+    manufacturing track; new Section 6.2 (design objects with 
+    `part_number`/`revision`); new Section 6.3 tightening 
+    `instance_of` to require a `design` target; new `supersedes`/
+    `superseded_by` relation pair.
+  - **A23: Authority transfer / domain death** — new Section 4.6: 
+    long-lived root authority key, new `authority_transfer` event 
+    type, authority record at `/.well-known/authority`, mirror hosts 
+    via `mirror_urls`, same-authority redirect rule relaxed for 
+    verified transfers. `/meta` document gains `root_key`, 
+    `mirror_urls`, `successor` fields.

--- a/spec/CHANGELOG.md
+++ b/spec/CHANGELOG.md
@@ -123,7 +123,7 @@ All notable changes to the PhIP specification will be documented in this file.
     basic/bearer/API-key MUST NOT route restricted reads or writes.
   - **A36: Conformance levels** — §13 restructured into Full / 
     Read-Only / Mirror / Client-Only classes. New 
-    `WRITE_NOT_SUPPORTED` (405) error code. New `conformance_class` 
+    `OPERATION_NOT_SUPPORTED` (405) error code. New `conformance_class` 
     field in `/meta`.
   - **A37: Schema versioning** — new §8.4: semver MAJOR.MINOR with 
     explicit additive vs. breaking change rules, versioned `$id` 

--- a/spec/phip-core.md
+++ b/spec/phip-core.md
@@ -179,6 +179,13 @@ PhIP URIs are permanent. A URI that has ever identified a PhIP Object MUST
 NOT be reassigned to a different object. A decommissioned or disposed object's 
 URI MUST continue to resolve, returning the object in its terminal state.
 
+Persistence of the URI is independent of persistence of the original 
+authority's DNS record or operational organization. An authority that 
+ceases operation, is acquired, or migrates to a new domain transfers 
+its records via the mechanism in Section 4.6 (Authority Transfer). 
+Section 4.3.3 redirect rules and Section 12.6 metadata `mirror_urls` 
+provide the runtime mechanics for clients to follow such transfers.
+
 ### 4.3 Resolution
 
 A PhIP URI is resolved via the authority's well-known resolver endpoint:
@@ -190,7 +197,87 @@ https://{authority}/.well-known/phip/resolve/{namespace}/{local-id}
 The authority MUST serve this endpoint over HTTPS. Resolution MUST return 
 the full PhIP Object or a standard error response.
 
-[TODO: define resolver discovery, caching headers, redirect behavior]
+#### 4.3.1 Resolver Discovery
+
+The default resolver for a URI `phip://{authority}/...` is reached by:
+
+1. Treating `{authority}` as a DNS name.
+2. Opening an HTTPS connection to that name on port 443.
+3. Requesting the path under `/.well-known/phip/` per RFC 8615.
+
+No additional discovery step is required. Clients MUST NOT perform DNS
+TXT, SRV, or similar lookups to locate a different resolver host — the
+authority name is the resolver's identity, and moving the resolver to a
+different host without keeping the authority name stable would break
+URI persistence (Section 4.2).
+
+An authority MAY publish a metadata document at
+`/.well-known/phip/meta` describing its supported protocol version,
+namespaces, and optional capabilities. The document format is defined in
+Section 12.6. Clients SHOULD fetch this document at most once per
+authority per session and cache it per the HTTP response headers.
+
+#### 4.3.2 Caching
+
+Resolver responses for GET `/resolve/` and GET `/history/` SHOULD include
+standard HTTP cache headers. The resolver SHOULD emit:
+
+- `ETag` — set to the object's current `history_head` for `/resolve/`
+  responses, or to a stable identifier for a committed history page.
+- `Cache-Control: private, max-age={seconds}` — resolver-chosen.
+  Resolvers SHOULD use a short `max-age` (≤ 60 seconds) for objects on
+  the manufacturing or operational track that may still receive events,
+  and MAY use a long `max-age` (days or more) for objects in terminal
+  states (`disposed`, `consumed`, `archived`) since their state cannot
+  change.
+
+Clients SHOULD:
+
+- Send `If-None-Match` with the cached `ETag` on subsequent fetches and
+  treat `304 Not Modified` as a confirmation that the cached projection
+  is current.
+- Invalidate all cached state for an object on any `CHAIN_CONFLICT`
+  received against it (the cached head is stale).
+- Re-verify the hash chain (Section 10.3) whenever the chain head
+  advances; a change of head MUST trigger re-verification from the last
+  verified point rather than from genesis.
+
+Clients MUST NOT cache responses from an untrusted resolver past the
+point where the signing key in `phip:keys` leaves a valid state
+(Section 11.2): a cached projection continues to be a valid snapshot of
+past history, but any new event observed after a key expires or is
+revoked MUST be re-verified against a currently-valid key.
+
+#### 4.3.3 Redirects
+
+Resolvers MAY respond with HTTP `301`, `307`, or `308` to redirect a
+client to a different URL — for example, to route through an internal
+reverse proxy or to steer traffic between replicas.
+
+Clients MUST follow redirects only when the redirect target's authority
+(the `host` component of the `Location` URL) is identical to the
+authority in the requested PhIP URI. A redirect that would change the
+authority MUST be treated as an error, and the client MUST NOT continue
+the request: a cross-authority redirect would silently re-bind a PhIP
+URI to a different organization, which violates URI persistence
+(Section 4.2) and creates a namespace-hijacking vector.
+
+**Exception — authority transfer.** A redirect that crosses authority 
+boundaries is permitted iff it is justified by a verified 
+`authority_transfer` event covering the requested namespace (Section 
+4.6). Resolvers signalling such a redirect SHOULD include a 
+`PhIP-Transfer-Event: <event-id>` header naming the transfer event. 
+Clients MUST resolve and verify the transfer event (per Section 4.6.3) 
+before following the redirect; an unverified transfer header MUST be 
+treated as if absent.
+
+Clients MUST NOT follow `302` redirects on `POST` operations
+(`CREATE`, `PUSH`, `QUERY`). Resolvers that need to redirect writes
+MUST use `307` or `308` so the method and body are preserved.
+
+Clients SHOULD limit redirect chains to five hops and treat longer
+chains as a resolver misconfiguration (surface as a transport-layer
+error, not a PhIP error envelope).
 
 ### 4.4 Sub-Object Addressing
 
@@ -206,12 +293,335 @@ The path structure implies a physical containment relationship, but the
 sub-object MUST also have an explicit `contained_in` relation to its parent 
 for the relationship to be normative. Path structure alone is informational.
 
-[TODO: define whether sub-objects require independent lifecycle states or 
-inherit from parent]
+#### 4.4.1 When to Register a Sub-Object
+
+A sub-part MUST be registered as an independent PhIP object — with its 
+own `phip_id`, event history, lifecycle state, and signing — when **any** 
+of the following holds:
+
+- The sub-part is field-replaceable (it can be removed, swapped, or 
+  installed without destroying the parent).
+- The sub-part has its own provenance trail (manufacturer, lot, 
+  certifications) that needs to be queryable independently.
+- The sub-part can be transferred to a different parent during its 
+  lifetime (e.g. an SSD moving between chassis, a battery moving 
+  between vehicles).
+- The sub-part has its own lifecycle state changes that do not coincide 
+  with the parent (e.g. a port `decommissioned` while the chassis is 
+  still `deployed`).
+
+Examples that MUST be independent objects: SSDs, DIMMs, NICs, line 
+cards, batteries, removable sensors, FRU modules.
+
+A sub-part MAY be modeled as an attribute facet on the parent — with no 
+independent PhIP record — when none of the above holds. In this case 
+the sub-part is part of the parent's object model and changes to it 
+flow through `attribute_update` events on the parent.
+
+Examples that MAY be facets: solder joints, PCB traces, stamped 
+features, integrated (non-removable) components, paint layers.
+
+#### 4.4.2 Lifecycle Independence
+
+Sub-objects that are independent (per 4.4.1) have their **own** 
+lifecycle state. A sub-object MUST NOT inherit state from its parent.
+
+A `decommissioned` chassis MAY contain a `deployed` line card if the 
+operator intends to harvest the line card for reuse. A `disposed` 
+parent does not transitively dispose of its still-physically-present 
+sub-objects; each sub-object's terminal state MUST be recorded by an 
+explicit `state_transition` event on that sub-object.
+
+When a parent object is consumed, decommissioned, or disposed, its 
+sub-objects' `contained_in` relations remain pointing at the parent 
+URI. Section 4.2 (URI persistence) ensures the parent URI continues to 
+resolve.
+
+#### 4.4.3 Path Segment Semantics
+
+URI path segments after the local-id are **purely informational**. They 
+provide a convenient lookup convention but carry no normative weight:
+
+- A sub-object SHOULD be resolvable both by its full path 
+  (`phip://acme.example/servers/srv-042/ports/eth0`) and by the 
+  flattened `phip_id` recorded in its object record. An authority MAY 
+  treat these as the same object or as distinct entries that point at 
+  the same underlying record.
+- The `contained_in` relation, **not** the path, is the source of 
+  truth for parent-child structure. Tools that infer hierarchy from 
+  path segments alone MUST be considered non-conformant.
+- An authority MAY register sub-objects with flat `phip_id`s 
+  (`phip://acme.example/ports/eth0-srv-042`) instead of nested paths. 
+  Both styles are conformant.
 
 ### 4.5 Authority Delegation
 
-[TODO: define how an authority may delegate a sub-namespace to another party]
+An authority MAY delegate a namespace (or a sub-prefix within a 
+namespace) to another party without transferring it. Delegation is 
+useful when a parent organization wants a subsidiary, contractor, or 
+business unit to operate its own slice of the namespace under the 
+parent's URI authority.
+
+Delegation differs from transfer (§4.6): the parent retains 
+ultimate authority and can revoke the delegation, whereas transfer 
+is a permanent cession.
+
+#### 4.5.1 Delegation Mechanism
+
+Delegation is recorded as an entry in the authority's metadata 
+document (§12.6) under a new `delegations` field:
+
+```json
+{
+  "delegations": [
+    {
+      "namespace": "logistics",
+      "prefix": "shipments/eu-",
+      "delegate_authority": "logistics-eu.partner.example",
+      "delegate_root_key": "phip://logistics-eu.partner.example/keys/root",
+      "scope": ["create", "push", "get", "history", "query"],
+      "effective_from": "2026-04-01T00:00:00Z",
+      "expires": "2027-04-01T00:00:00Z"
+    }
+  ]
+}
+```
+
+| Field | Required | Description |
+|---|---|---|
+| `namespace` | MUST | Namespace name being delegated. Use `"*"` to delegate the entire authority (rare; usually transfer is more appropriate) |
+| `prefix` | MAY | Local-id prefix the delegation applies to. If omitted, applies to the entire namespace |
+| `delegate_authority` | MUST | Authority name that operates the delegated slice |
+| `delegate_root_key` | MUST | PhIP URI of the delegate's root key |
+| `scope` | MUST | Operations the delegate may perform: subset of `["create", "push", "get", "history", "query"]` |
+| `effective_from` | MUST | ISO 8601 timestamp the delegation begins |
+| `expires` | MAY | Optional expiry; an absent `expires` indicates an open-ended delegation |
+| `revocable` | MAY | Boolean. If `true`, the parent authority may revoke the delegation by removing the entry from its metadata document. Default `true` |
+
+#### 4.5.2 Resolution Under Delegation
+
+A client resolving `phip://parent.example/{namespace}/{local-id}` 
+SHOULD:
+
+1. Fetch the parent's `/meta` document and check `delegations`.
+2. If a delegation entry matches the requested namespace and 
+   prefix, follow the parent's redirect to the delegate's resolver. 
+   The redirect MUST be accompanied by a `PhIP-Delegation: 
+   <delegation-namespace>` header so the client knows the basis 
+   for the cross-authority redirect.
+3. Verify the delegate's responses by chaining trust from the 
+   parent's root key to the delegate's root key (the delegation 
+   entry in the parent's `/meta` constitutes the trust bridge).
+4. Cache the delegation per `Cache-Control` headers; re-fetch on 
+   `effective_from`/`expires` boundary or on cache invalidation.
+
+The same-authority redirect rule (§4.3.3) is relaxed for verified 
+delegations, by analogy to the transfer exception.
+
+#### 4.5.3 Writes Under Delegation
+
+CREATE and PUSH operations against a delegated slice MUST be sent 
+to the delegate's resolver, not the parent's. The parent's resolver 
+MAY choose to:
+
+- Reject CREATEs in the delegated slice with `FOREIGN_NAMESPACE` 
+  (the delegate is now the owner of that slice).
+- Forward via `307`/`308` redirect to the delegate.
+
+Either is conformant. Authorities SHOULD document their behavior 
+in the `/meta` document.
+
+#### 4.5.4 Revocation
+
+Revocation of a delegation is a metadata change at the parent's 
+`/meta` endpoint: the delegation entry is removed (or has its 
+`expires` shortened to a past time). After revocation:
+
+- New writes to the delegated slice at the delegate's resolver 
+  remain locally valid but are no longer recognized by the parent.
+- Reads SHOULD continue to be served by the delegate for the 
+  pre-revocation history. The parent SHOULD publish mirror URLs 
+  (§4.6.5) covering the revoked slice if the delegate becomes 
+  uncooperative.
+- Hash chains accumulated during the delegation period remain 
+  valid. The parent does not retroactively invalidate the chain — 
+  it just stops accepting new events under the parent's authority 
+  for that slice.
+
+Resolvers SHOULD log delegation revocations and SHOULD make them 
+visible via `/meta` history (an authority's `/meta` document is 
+itself addressable as a PhIP object — its event history records 
+delegation lifecycles).
+
+#### 4.5.5 Sub-Delegation
+
+A delegate MAY further delegate its slice if its root key is used to 
+sign the sub-delegation entry in its own `/meta`. Sub-delegation 
+chains MUST NOT exceed the depth permitted by the original parent. 
+The original parent MAY constrain depth via a `max_subdelegation` 
+field on the delegation entry; absence means unlimited depth, which 
+is RECOMMENDED only for trusted partner relationships.
+
+### 4.6 Authority Transfer
+
+PhIP URIs MUST keep resolving past the operational lifetime of the 
+original authority (Section 4.2). When an authority is acquired, 
+renamed, dissolved, or otherwise becomes unable to host its own 
+resolver, it transfers control of its namespaces to a successor via 
+the mechanism in this section.
+
+This section defines the cryptographic and protocol machinery; 
+governance — who is allowed to declare an authority defunct, how 
+disputes are resolved — is outside the scope of v0.1.
+
+#### 4.6.1 Root Authority Key
+
+Each authority SHOULD provision a **root authority key**: a long-lived 
+Ed25519 keypair held in cold storage and used **only** to sign 
+authority-level events. The root key is distinct from operational 
+signing keys (Section 11.2).
+
+The root key is published as a key resource on the operational track 
+under a well-known local-id:
+
+```
+phip://{authority}/keys/root
+```
+
+The root key resource SHOULD use a long validity window 
+(`not_after` ≥ 10 years from `not_before`) and SHOULD NOT be used to 
+sign individual events. Its purpose is to authorize transfer events 
+and to anchor trust when the authority is no longer reachable.
+
+An authority that does not provision a root key MAY still operate but 
+forfeits the ability to perform a verifiable authority transfer; in 
+practice, its URIs become irrecoverable when the DNS name expires.
+
+#### 4.6.2 The authority_transfer Event
+
+Authority transfer is recorded as a new event type:
+
+| Type | Description |
+|---|---|
+| `authority_transfer` | The authority of one or more namespaces is transferred to a successor. MUST be signed by the source authority's root key |
+
+The event is appended to a special **authority record**:
+
+```
+phip://{authority}/.well-known/authority
+```
+
+This is a PhIP object of type `actor` representing the authority 
+itself. Its history records key rotations, namespace registrations, 
+and any transfer events. The authority record's `created` event MUST 
+be signed by the root key (a self-signed bootstrap, per Section 
+11.2.4 conventions adapted for the authority record).
+
+An `authority_transfer` event payload:
+
+```json
+{
+  "type": "authority_transfer",
+  "payload": {
+    "namespaces": ["parts", "lots", "racks"],
+    "successor_authority": "newco.example",
+    "successor_root_key": "phip://newco.example/keys/root",
+    "effective_from": "2027-01-01T00:00:00Z",
+    "rationale": "Acme acquired by NewCo (2026-12-15). Sole transfer of all asset records."
+  }
+}
+```
+
+| Field | Required | Description |
+|---|---|---|
+| `namespaces` | MUST | Array of namespace strings transferred. MAY be `["*"]` to transfer all namespaces under the authority |
+| `successor_authority` | MUST | Authority name (DNS label) the namespaces transfer to |
+| `successor_root_key` | MUST | PhIP URI of the successor's root key resource. Verifiers MUST resolve and validate this key before accepting subsequent events under the transferred namespaces |
+| `effective_from` | MUST | ISO 8601 timestamp at which the transfer takes effect. Events appended after this timestamp under the transferred namespaces SHOULD be hosted by the successor |
+| `rationale` | SHOULD | Human-readable explanation |
+
+After `effective_from`, GETs to the source authority for objects in 
+the transferred namespaces SHOULD respond with `308 Permanent 
+Redirect` to the successor's URL (Section 4.3.3 same-authority 
+redirect rule is relaxed for transferred objects — see 4.6.4).
+
+#### 4.6.3 Verification
+
+A client receiving an object whose history includes events under both 
+the source and successor authorities MUST verify:
+
+1. The chain is intact across the transfer point (no break in 
+   `previous_hash` continuity).
+2. The transfer event is signed by the source authority's root key.
+3. The source authority's root key was within its validity window at 
+   `effective_from`.
+4. Events appended after `effective_from` under the transferred 
+   namespaces are signed by keys whose chain of trust roots in the 
+   successor's root key.
+5. The transfer event's `successor_authority` matches the authority 
+   serving the post-transfer events.
+
+If any of these checks fail, the client MUST reject the chain as 
+non-authentic. Implementations SHOULD cache root key fingerprints out 
+of band (e.g., trust-on-first-use with explicit pinning for 
+high-stakes deployments) to mitigate the risk of root key compromise.
+
+#### 4.6.4 Redirects After Transfer
+
+The same-authority-only redirect rule in Section 4.3.3 has one 
+exception: a redirect from the source authority to the successor 
+authority is permitted **iff** the response includes (or the client 
+has previously fetched and cached) a valid `authority_transfer` event 
+covering the requested object's namespace.
+
+Resolvers MAY signal a transfer to clients via a 
+`PhIP-Transfer-Event: <event-id>` HTTP header on the redirect, naming 
+the transfer event the redirect is justified by. Clients that have not 
+yet seen this event MUST fetch it from either the source or successor 
+authority record before following the redirect.
+
+#### 4.6.5 Mirrors and Archival
+
+When the source authority is unreachable (DNS expiration, server 
+shutdown), clients fall back to mirrors listed in the successor's 
+metadata document (Section 12.6 `mirror_urls`). A mirror is a 
+read-only host serving a frozen snapshot of the source authority's 
+records as of `effective_from` (or a later snapshot if the source 
+continued to operate post-transfer).
+
+Mirrors MUST serve the snapshot under the source authority's URI 
+namespace (`/.well-known/phip/resolve/{namespace}/{local-id}`) so 
+that hash chains continue to verify byte-for-byte. Mirror responses 
+MUST set `Cache-Control: public, immutable` and SHOULD set a long 
+`max-age` (≥ 1 year), since mirrored data does not change.
+
+A client that retrieves an object from a mirror MUST verify the 
+authority-transfer chain back to the original authority record, not 
+just the local hash chain. This prevents a malicious mirror from 
+serving a forked history.
+
+#### 4.6.6 Multiple Transfers
+
+An authority that has already received transfers MAY transfer 
+namespaces onward. The verification chain extends accordingly: a 
+client validating an object that has passed through three authorities 
+MUST verify two transfer events, each signed by the previous 
+authority's root key. There is no fixed depth limit; resolvers SHOULD 
+limit transfer-chain depth to a configurable maximum (RECOMMENDED: 
+10) to bound verification cost.
+
+#### 4.6.7 Non-Goals
+
+This section deliberately does not specify:
+
+- Who decides an authority is defunct. (Governance is out of scope.)
+- How root keys are recovered or rotated under coercion. (Recovery 
+  procedures are an authority's internal concern.)
+- Cross-authority dispute resolution if two parties claim to be 
+  successors. (Off-protocol; rely on the legal record.)
+
+These are real problems. v0.1 provides the cryptographic primitive; 
+operational ecosystems will need to build governance on top.
 
 ---
 
@@ -259,6 +669,52 @@ informational and MUST NOT be used as the primary identifier in place of
 
 [TODO: define additional standard identity fields]
 
+#### 5.2.1 Uncertainty Qualifiers
+
+When ingesting legacy systems or rebuilding records from incomplete 
+sources, identity fields are often imperfectly known. PhIP does not 
+require certainty: any identity field MAY be qualified by appending a 
+parallel `_quality` field carrying provenance metadata.
+
+```json
+{
+  "identity": {
+    "serial": "QCT88421-0042",
+    "serial_quality": {
+      "confidence": "high",
+      "source": "manufacturer_label_scan",
+      "as_of": "2026-04-12T09:00:00Z"
+    },
+    "lot": "2026-Q1-BATCH-04",
+    "lot_quality": {
+      "confidence": "low",
+      "source": "operator_recollection",
+      "note": "lot label damaged; inferred from adjacent units"
+    }
+  }
+}
+```
+
+A `_quality` object MAY contain:
+
+| Field | Description |
+|---|---|
+| `confidence` | One of `high`, `medium`, `low`, `unverified`. `high` = direct observation or trusted source; `unverified` = transcribed without checking |
+| `source` | Free-text provenance (`manufacturer_label_scan`, `erp_export_2024`, `operator_recollection`, `inferred`) |
+| `as_of` | ISO 8601 timestamp the value was last verified |
+| `corrected_from` | Previous value if this field has been corrected. Useful for legacy onboarding |
+| `note` | Free-text context |
+
+Tools that consume identity fields MUST handle the qualified form 
+identically to the unqualified form for matching and equality. 
+`_quality` is metadata only — it does not change the field's value 
+semantics.
+
+The convention applies to any identity field. A field named `serial` 
+has its qualifier as `serial_quality`; `part_number` → 
+`part_number_quality`. Resolvers MUST NOT enforce that qualifiers 
+exist for any particular field.
+
 ### 5.3 Minimal Valid Object
 
 ```json
@@ -287,6 +743,7 @@ constrains which relations and lifecycle transitions are valid.
 | `vehicle` | A mobile location: truck, train car, ship, drone. May carry objects via `contains` and has a position that changes over time |
 | `lot` | A logical grouping of identical items sharing a production identity |
 | `actor` | A person, organization, or automated system that pushes events |
+| `design` | A design specification or part-number revision. Target of `instance_of` relations. Has no physical instance. See Section 6.2 |
 
 Custom types are NOT permitted in the core vocabulary. Domain extensions 
 that require additional types SHOULD be proposed as amendments to this spec.
@@ -303,7 +760,120 @@ vehicle object. Continuous GPS telemetry SHOULD NOT be stored as PhIP events;
 instead, a PhIP `attribute_update` SHOULD capture waypoints at meaningful 
 state changes (departure, arrival, border crossing).
 
-[TODO: define geographic position attribute schema]
+The standard schema for position, address, route, and geofence data is 
+the `phip:geo` namespace (`schemas/geo.json`). Vehicles and locations 
+SHOULD use it; custom geographic schemas are permitted but reduce 
+interoperability.
+
+### 6.2 Design Objects
+
+A `design` object represents a specification, part-number revision, or 
+build target — the abstract definition of a thing, not a physical 
+instance. Designs are the target of `instance_of` relations from 
+physical objects (components, assemblies, systems).
+
+PhIP does not aim to replace product lifecycle management (PLM) systems 
+such as Windchill, Teamcenter, or Arena. The `design` type is a thin 
+addressable handle that lets `instance_of` resolve to a verifiable 
+target across organizational boundaries — the authoritative design 
+content typically lives in a PLM system referenced via 
+`phip:external_record` (Section 15.3).
+
+A `design` object MUST include the following identity fields:
+
+| Field | Required | Description |
+|---|---|---|
+| `part_number` | MUST | Manufacturer's part number for the design |
+| `revision` | MUST | Design revision identifier (e.g. `"A"`, `"3.2"`, `"2026-04-rev-7"`) |
+| `description` | SHOULD | Human-readable description |
+| `external_ref` | MAY | URL of the canonical design document in a PLM, drive, or other system |
+
+Design objects follow the manufacturing track lifecycle (Section 9.2). 
+The states map to design release status:
+
+- `concept` — initial idea; subject to change
+- `design` — actively under design work
+- `prototype` — in physical prototyping
+- `qualified` — design is approved
+- `stock` — released for production use; physical objects MAY 
+  `instance_of` this revision
+- `decommissioned` — superseded; new physical objects SHOULD NOT use 
+  this revision but existing instances remain valid
+- `consumed` / `disposed` — design is retired
+
+Design revisions are separate `design` objects, linked via the 
+`supersedes` relation (Section 7.1). A new revision does not invalidate 
+physical objects that `instance_of` the prior revision; their 
+provenance trail continues to point at the revision they were actually 
+built against.
+
+### 6.3 instance_of Target Constraint
+
+The `instance_of` relation MUST target a `design` object. An 
+`instance_of` relation pointing at any other object type is invalid 
+and MUST be rejected by the resolver with `INVALID_RELATION` (422).
+
+This is a tightening of Section 7. Implementations published before 
+this revision of the spec MAY have written `instance_of` relations 
+pointing at `component` or `system` objects acting as informal type 
+records. Authorities migrating to this version SHOULD register 
+corresponding `design` objects and rewrite the relations via 
+`relation_removed` + `relation_added` event pairs.
+
+### 6.4 Lot Identity: Fungibility and Quantity
+
+Lot objects represent groupings of identical or interchangeable items. 
+Two fields on a `lot`'s `identity` are normative:
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `fungible` | boolean | MUST | `true` if the lot's units are mutually interchangeable for downstream use; `false` if individual units retain distinct identity within the lot |
+| `quantity` | object | SHOULD | Current quantity. See 6.4.1 |
+
+**Fungible lots** (`fungible: true`) — bulk materials (resin pellets, 
+solder paste, copper bars), commodity ingredients (coffee beans, 
+flour), and any grouping where pulling 1 kg from one end is 
+equivalent to pulling 1 kg from the other. Fungible lots support 
+`lot_split` and `lot_merge` operations freely.
+
+**Non-fungible lots** (`fungible: false`) — batches of serialized 
+items (a tray of 24 PCBs each with their own serial number, a pallet 
+of named LiDAR units). Non-fungible lots SHOULD also be modeled as 
+parents-of-components via `contains` relations to the individual 
+items. `lot_split` on a non-fungible lot MUST preserve the identity 
+of each contained item; the `resulting_lots` payload MUST list which 
+items go to which resulting lot.
+
+When `fungible` is absent, the resolver MUST treat the lot as 
+fungible. New authorities SHOULD set the field explicitly.
+
+#### 6.4.1 Quantity Tracking
+
+A lot's `identity.quantity` field is an object with these fields:
+
+| Field | Required | Description |
+|---|---|---|
+| `value` | MUST | Numeric quantity. MUST be ≥ 0 |
+| `unit` | MUST | SI unit symbol (`kg`, `g`, `m`, `L`, `units`, etc.) |
+| `as_of` | SHOULD | ISO 8601 timestamp of the most recent measurement |
+| `precision` | MAY | Quantity precision (e.g., `0.001` for milligram precision on a kg-scale). Used as the conservation tolerance `ε` in §10.5.1 |
+
+The current quantity is a projection of the event history. Each 
+`lot_split`, `lot_merge`, and `attribute_update` that changes the 
+quantity MUST be reflected by updating the lot's `identity.quantity`. 
+The lot history is the authoritative record; the `identity.quantity` 
+field is a convenience.
+
+When a lot is partially consumed by a `process` event without a full 
+split (e.g., 2 kg drawn from a 10 kg lot for a single build), the 
+authority SHOULD emit an `attribute_update` event reducing 
+`identity.quantity.value` accordingly. The remaining lot keeps its 
+`phip_id`. This is the lightweight pattern for routine draw-down — 
+`lot_split` is for events that produce new addressable sub-lots.
+
+`quantity` is not strictly required for non-fungible lots that 
+maintain a `contains` relation to every member, since the count is 
+derivable. Authorities MAY include it anyway for query convenience.
 
 ---
 
@@ -321,7 +891,8 @@ PhIP Objects. Each relation is a tuple of (type, phip_id).
 | `located_at` | — | Current position. Target MUST be of type `location` or `vehicle` |
 | `derived_from` | — | Material provenance. The subject was produced from the object. Multiple `derived_from` relations express many-to-one derivation (e.g., metals recovered from multiple sources) |
 | `replaces` | `replaced_by` | Temporal substitution. Subject took the place of object |
-| `instance_of` | — | The subject is a physical instance of a design or part number |
+| `instance_of` | — | Subject is a physical instance of a design. Target MUST be of type `design` (Section 6.3) |
+| `supersedes` | `superseded_by` | Subject `design` revision replaces an older `design`. Both endpoints MUST be of type `design` |
 | `manufactured_by` | — | Object MUST be of type `actor` |
 
 ### 7.2 Relation Format
@@ -382,7 +953,96 @@ A `relation_removed` event payload uses the same structure — the
 Relation metadata is not namespaced (unlike object attributes) because 
 it carries simple positional or structural data, not rich domain schemas.
 
-### 7.3 Custom Relations
+### 7.3 Bidirectional Relations Across Authorities
+
+Some relations are inherently bidirectional: `connected_to` describes 
+an interface link that is symmetric by physics, and `contains` /
+`contained_in` are inverses. When both endpoints live under the same 
+authority, the resolver can validate that both sides agree. When the 
+endpoints span authorities, **only the side under the writing 
+authority can be enforced**.
+
+The rules:
+
+- A relation is **owned** by the object it is attached to (per §7.2). 
+  An object's relations are mutable only by that object's authority 
+  or by holders of capability tokens (§11.3).
+- For `connected_to`, the writing authority MUST emit a 
+  `relation_added` on its own object. The far-side object's 
+  authority is expected (but not required) to emit a matching 
+  `relation_added` of their own. The two events are independent.
+- A `relation_added` event referencing a far-side `phip_id` MUST 
+  NOT trigger any write on the far-side authority. Cross-authority 
+  writes only happen via capability tokens (§11.3) and are explicit.
+- Verifiers reading either side MAY check that the other side has 
+  also recorded the relation. **Asymmetric relations 
+  (one-side-only) MUST NOT be treated as proof of an actual physical 
+  connection** — they may indicate a misconfiguration, a stale 
+  record, or a deliberately partial view.
+
+For `connected_to` specifically, the convention is:
+
+```json
+// On rack-007 (Acme):
+{ "type": "connected_to", "phip_id": "phip://quanta.com/servers/Q88421" }
+
+// On Q88421 (Quanta), if Quanta wishes to record the connection:
+{ "type": "connected_to", "phip_id": "phip://acme.example/racks/rack-007" }
+```
+
+Quanta is under no obligation to record the inverse. Tools that need 
+strong topology guarantees SHOULD prefer modeling both endpoints 
+under one authority's namespace, or use cross-authority 
+attestations that are explicitly signed by both parties (out of 
+scope for v0.1).
+
+For `contains` / `contained_in`, the same asymmetry holds. An 
+authority that places an object inside a foreign container records 
+`contained_in` on its own object; the container's authority is 
+free to record the inverse `contains` or not. Resolvers MUST NOT 
+require the inverse to be present.
+
+### 7.4 Dangling Relations
+
+A relation references a `phip_id` that may, at any later time:
+
+- Be unreachable (the target authority is offline or has been 
+  transferred without a reachable mirror).
+- Return `404 OBJECT_NOT_FOUND` (the target was never registered or 
+  was registered under a different `phip_id`).
+- Return `403 ACCESS_DENIED` (the target is private to another 
+  reader; §11.5).
+- Resolve to a different object than expected (e.g. due to a 
+  malicious authority).
+
+PhIP does **not** guarantee referential integrity across the 
+federation. The protocol is link-style, not foreign-key-style.
+
+Consumers MUST handle dangling relations gracefully:
+
+- Treat unreachable targets as **unknown**, not as evidence of 
+  malformed data. Surface the unreachability to operators rather 
+  than silently dropping the relation.
+- Cache last-known state of frequently referenced foreign objects 
+  to reduce the visible failure rate.
+- On `OBJECT_NOT_FOUND` from a once-resolvable target, retain the 
+  relation (the target may return) but flag the link as stale.
+
+A new error code conveys the case where a relation in an event 
+references a target that fails an integrity check the resolver does 
+enforce locally:
+
+| Code | HTTP | Description |
+|---|---|---|
+| `DANGLING_RELATION` | 422 | A `relation_added` event references a `phip_id` that the resolver was asked to verify and could not (e.g., the target lives in this authority's namespace but does not exist) |
+
+`DANGLING_RELATION` is emitted only for **same-authority** lookups — 
+when a relation_added in namespace A points at namespace A and the 
+target does not exist. Cross-authority targets MUST NOT produce this 
+error; they are accepted as-written and verified lazily by the 
+reader.
+
+### 7.5 Custom Relations
 
 Custom relations MAY be used under a namespaced type:
 
@@ -426,6 +1086,9 @@ namespace. This is the primary extensibility mechanism.
 | `phip:software` | Firmware, software versions, config hashes | Defined — `schemas/software.json` |
 | `phip:datacenter` | Rack position, power, thermal | Defined — `schemas/datacenter.json` |
 | `phip:compliance` | Certifications, life limits, chain of custody | Defined — `schemas/compliance.json` |
+| `phip:geo` | Geographic position, address, route, geofence | Defined — `schemas/geo.json` |
+| `phip:access` | Read access policy (Section 11.5) | Defined — `schemas/access.json` |
+| `phip:keys` | Public key material on actor objects (Section 11.2) | Defined inline in Section 11.2 |
 | `phip:procurement` | PO number, supplier, lead time | [TODO] |
 
 ### 8.3 Custom Namespaces
@@ -449,7 +1112,7 @@ Not all object types follow the same lifecycle. PhIP defines two tracks:
 
 **Manufacturing track** — for types that are designed, produced, and 
 eventually end-of-lifed: `material`, `component`, `assembly`, `system`, 
-`lot`.
+`lot`, `design`.
 
 **Operational track** — for types that exist to support the protocol and 
 don't go through a manufacturing lifecycle: `actor`, `location`, `vehicle`.
@@ -591,6 +1254,7 @@ Each event MUST contain:
 | `lot_split` | A lot was divided into two or more new lots. See 10.5 |
 | `lot_merge` | Two or more lots were combined into one. See 10.5 |
 | `note` | Free-text annotation |
+| `authority_transfer` | Authority over one or more namespaces transferred to a successor. MUST be signed by the source authority's root key and appear in the authority record. See Section 4.6 |
 
 ### 10.3 Hash Chain
 
@@ -668,6 +1332,53 @@ The `yield_fraction` field is OPTIONAL and represents the mass fraction of
 the input that contributed to this output. This enables proportional 
 provenance tracking for regulated materials.
 
+#### 10.4.1 Yield Fraction Semantics
+
+When `yield_fraction` is supplied on outputs, the values MUST be 
+non-negative real numbers in the closed interval `[0, 1]`.
+
+The yield fractions on outputs that share a single input describe how 
+that input was distributed across outputs. For each input referenced 
+by one or more outputs, the sum of `yield_fraction` values on outputs 
+that point at that input via `derived_from` MUST satisfy:
+
+```
+sum(yield_fraction_i) ≤ 1.0 + ε
+```
+
+where `ε` is a small rounding tolerance. Authorities SHOULD use 
+`ε = 1e-6`. A sum strictly less than 1 is permitted — it represents 
+material loss (slag, scrap, evaporation) that is not tracked as a 
+distinct output.
+
+A sum exceeding `1 + ε` MUST be rejected by the resolver with 
+`INVALID_EVENT` (422). Sums exceeding 1 imply mass duplication, which 
+violates conservation.
+
+When an input has multiple `derived_from` outputs but yield fractions 
+are absent, the resolver MAY treat the fractions as unspecified rather 
+than implicit-equal-share — equal-share would be a guess, and absence 
+is more honest. Tools that compute aggregate provenance SHOULD treat 
+missing fractions as "unknown" and propagate uncertainty rather than 
+substituting `1/N`.
+
+#### 10.4.2 Numerical Representation
+
+`yield_fraction` is serialized as a JSON number per RFC 8785 (JCS) — 
+the canonical form is the shortest round-trip ECMAScript representation 
+(Section 10.3). Authorities SHOULD avoid yield fractions with more than 
+six significant digits; finer precision is below the rounding tolerance 
+and creates spurious chain divergence.
+
+When a single input is split across many outputs (e.g. a copper lot 
+distributed across 100 cable spools), the recommended pattern is to 
+quote each output's yield as a fraction with explicit shared 
+denominator (e.g. `0.01` for each of 100 equal shares). Renormalizing 
+to compensate for floating-point drift after the fact MUST NOT mutate 
+already-emitted events; if the sum exceeds tolerance, the authority 
+MUST emit a corrective `process` event (typically representing the 
+lost or unaccounted material as an explicit output).
+
 ### 10.5 Lot Operations
 
 Lots may be split or merged during their lifecycle.
@@ -705,6 +1416,52 @@ pointing to all sources.
   }
 }
 ```
+
+#### 10.5.1 Quantity Conservation
+
+When source and resulting lots carry a quantity field 
+(`quantity_kg`, `quantity_units`, etc.; see §6.4), lot operations 
+MUST satisfy mass conservation within a small tolerance.
+
+**Lot Split.** Sum of resulting `quantity_*` values MUST satisfy:
+
+```
+sum(resulting) ≤ source_quantity + ε
+```
+
+A sum strictly less than the source quantity is permitted — it 
+represents recorded loss (the `reason` field SHOULD describe it: 
+`partial_spoilage`, `sampling_loss`). The lot_split payload MAY 
+include a `loss_quantity` field naming the lost amount explicitly:
+
+```json
+{ "type": "lot_split", "payload": { "loss_quantity_kg": 200, ... } }
+```
+
+A split where `sum(resulting) + loss_quantity > source_quantity + ε` 
+MUST be rejected with `INVALID_EVENT` (422).
+
+**Lot Merge.** Sum of source `quantity_*` values MUST equal the 
+resulting lot's quantity within tolerance:
+
+```
+abs(sum(source) - resulting_quantity) ≤ ε
+```
+
+Mergers that introduce mass (e.g., adding a non-tracked filler) MUST 
+NOT use `lot_merge`; a `process` event with the filler as an explicit 
+input is the correct representation.
+
+**Tolerance.** `ε` SHOULD be set to the smaller of:
+- 0.1 % of the source quantity, or
+- the unit precision of the relevant measurement (e.g. ε = 1g for 
+  measurements taken on a gram-precision scale).
+
+Resolvers MUST validate conservation only when **all** participating 
+lots carry comparable quantity fields. Splits or merges between lots 
+with mismatched units (`quantity_kg` and `quantity_units`) MUST NOT 
+be silently allowed; the authority SHOULD emit a `process` event 
+instead, since unit conversion is a transformation.
 
 The `source_lots` array MUST contain at least two entries. Each source 
 lot SHOULD be transitioned to `consumed` by the pushing actor.
@@ -884,15 +1641,24 @@ any object whose `phip_id` starts with that prefix.
 | `push_state` | Append `state_transition` events only |
 | `push_measurements` | Append `measurement` events only |
 | `push_relations` | Append `relation_added` and `relation_removed` events only |
+| `read_state` | Read object projection via GET (no history) |
+| `read_history` | Read object projection AND full event history |
+| `read_query` | Match objects via QUERY |
 
 A token with `push_events` scope is a broad grant. The narrower scopes 
 allow fine-grained delegation: a carrier transporting goods may receive 
 `push_relations` (to update `located_at`) but not `push_state`. A sensor 
 may receive `push_measurements` but nothing else.
 
+The `read_*` scopes gate access to objects whose `phip:access` policy 
+restricts reads (Section 11.5). A token MAY combine read and write 
+scopes by being issued multiple times with different scope values; a 
+single token has exactly one scope.
+
 #### 11.3.3 Token Presentation
 
-Capability tokens are presented via HTTP header on PUSH requests:
+Capability tokens are presented via HTTP header on PUSH, GET, and QUERY 
+requests:
 
 ```
 Authorization: PhIP-Capability <base64url-encoded-token>
@@ -952,6 +1718,44 @@ carrier, allowing the carrier to push `relation_added` and
 `relation_removed` events for `located_at` relations on the shipped 
 objects.
 
+#### 11.3.7 Multi-Party Custody Transfers
+
+A custody transfer involves three actors: the **prior custodian** 
+(who held the goods), the **carrier** (who moves them), and the 
+**next custodian** (who receives them). The `located_at` relation on 
+each shipped object MUST track this chain.
+
+The recommended pattern:
+
+1. The prior custodian issues a capability token with 
+   `push_relations` scope, `granted_to` the carrier, and 
+   `object_filter` matching the shipped objects. The token's 
+   `expires` SHOULD bound the expected transit window plus a small 
+   buffer.
+2. At pickup, the carrier emits `relation_removed` for the previous 
+   `located_at` (e.g., the warehouse) and `relation_added` for the 
+   carrier's vehicle.
+3. In transit, the carrier MAY emit further `attribute_update` 
+   events on the vehicle (position via `phip:geo`) but SHOULD NOT 
+   emit further `located_at` updates on the goods until handoff.
+4. At delivery, the carrier emits a final `relation_removed` (off 
+   the vehicle) and `relation_added` (at the next custodian's 
+   location). The carrier's token SHOULD be allowed to expire 
+   shortly after.
+5. The next custodian, on accepting the goods, MAY then issue their 
+   own tokens for downstream handling.
+
+If transit is interrupted (theft, accident, force majeure), the 
+prior custodian retains the right to update relations on the goods 
+since the original token has not been revoked. They SHOULD emit a 
+`note` event documenting the disruption and SHOULD revoke the 
+carrier's token (per §11.3.5) before re-routing.
+
+The carrier MUST NOT issue capability tokens of their own against 
+the shipped objects — they hold a delegated capability, not 
+ownership. Sub-delegation requires the prior custodian to issue a 
+new token directly to the sub-carrier.
+
 ### 11.4 Automated and IoT Actors
 
 Automated systems (IoT sensors, MES controllers, OTA update services) are 
@@ -980,8 +1784,157 @@ Instead:
 - A `measurement` event MAY reference an external telemetry source via a 
   URL in its payload for detailed data.
 
-[TODO: define standard payload format for measurement events referencing 
-external telemetry]
+#### 11.4.2 Measurement Event Payload
+
+A `measurement` event MUST carry a payload of the following shape:
+
+```json
+{
+  "type": "measurement",
+  "payload": {
+    "metric": "internal_temperature_c",
+    "value": 87.4,
+    "unit": "°C",
+    "as_of": "2026-04-23T14:32:11Z",
+    "method": "ntc_thermistor",
+    "uncertainty": 0.5,
+    "thresholds": {
+      "warning": 80,
+      "critical": 95
+    },
+    "outcome": "warning",
+    "external_ref": {
+      "url": "https://telemetry.acme.example/series/srv-042/temp?from=...&to=...",
+      "content_hash": "sha256:8f4a...",
+      "media_type": "application/json",
+      "window": {
+        "from": "2026-04-23T14:00:00Z",
+        "to": "2026-04-23T15:00:00Z"
+      }
+    },
+    "samples": 360
+  }
+}
+```
+
+| Field | Required | Description |
+|---|---|---|
+| `metric` | MUST | Identifier for what was measured (e.g. `internal_temperature_c`, `vibration_rms_mm_s`, `pressure_psi`). SHOULD reuse a domain vocabulary; custom metrics SHOULD be namespaced (`acme:nozzle_flow`) |
+| `value` | MUST | Numeric or string measurement result. For derived results (`pass`/`fail`, `warning`), use a string |
+| `unit` | SHOULD | SI or domain unit symbol. Omitted for unitless metrics or pass/fail outcomes |
+| `as_of` | MUST | ISO 8601 timestamp the measurement applies to (the observation time, not the push time) |
+| `method` | MAY | Free-text or controlled identifier for measurement method or instrument class |
+| `uncertainty` | MAY | Numeric 1-σ uncertainty in the same `unit` as `value` |
+| `thresholds` | MAY | Object naming the limits used to interpret the result. Common keys: `warning`, `critical`, `nominal_min`, `nominal_max` |
+| `outcome` | MAY | Conclusion drawn from the measurement: `nominal`, `warning`, `critical`, `pass`, `fail`, `out_of_range` |
+| `external_ref` | MAY | Pointer to detailed telemetry the measurement is summarizing or derived from. Format follows §15.3 (`url`, `content_hash`, `media_type`) plus an optional `window` describing the time range |
+| `samples` | MAY | If derived from aggregated telemetry, the number of underlying samples |
+
+The `external_ref.window` field SHOULD be present whenever 
+`external_ref.url` returns time-series data — it lets verifiers 
+re-derive the measurement from raw data without ambiguity about 
+which slice was used.
+
+A measurement that exists purely as a `value` + `as_of` (no 
+external reference) is conformant. The external reference is for 
+auditability when the source data is voluminous or proprietary.
+
+Resolvers MUST NOT validate `metric` against a controlled vocabulary 
+in v0.1; this would prevent domain extension. They SHOULD reject 
+measurements whose `value` type does not match `unit` (e.g., a 
+string `value` with a numeric unit makes no sense).
+
+The `outcome` field is a derived assessment, not a raw datum. 
+Authorities MAY emit subsequent `measurement` events with different 
+`outcome` values if interpretation thresholds are revised; the 
+historical `outcome` records what was concluded at the time. This 
+distinction matters for regulated domains where the conclusion 
+itself is auditable.
+
+### 11.5 Read Access Control
+
+PhIP objects are publicly readable by default. An authority MAY restrict
+read access by attaching a `phip:access` attribute to an object.
+
+#### 11.5.1 Access Policy
+
+The `phip:access` attribute namespace defines a single field, `policy`,
+whose value is one of:
+
+| Policy | Meaning |
+|---|---|
+| `public` | Anyone may GET, read history, and match in QUERY. Default if `phip:access` is absent. |
+| `authenticated` | Caller MUST present a valid capability token with any `read_*` scope, regardless of `granted_to` |
+| `capability` | Caller MUST present a capability token whose `granted_to` matches the requesting actor and whose scope covers the requested operation |
+| `private` | No external reads. Only the authority itself may read. |
+
+The policy applies to GET (`/resolve/`), GET history (`/history/`), and 
+QUERY (`/query/`). It does not apply to PUSH or CREATE — those are 
+gated separately by the existing write scopes.
+
+The `phip:access` attribute MUST be writable only by the authority that 
+owns the object. Attempts to update `phip:access` from a foreign 
+namespace MUST be rejected with `FOREIGN_NAMESPACE` (403) regardless of 
+any held capability tokens.
+
+#### 11.5.2 Resolution Order
+
+For a GET, GET-history, or QUERY request the resolver MUST evaluate, in 
+order:
+
+1. If the object's `phip:access.policy` is `public` (or `phip:access` is 
+   absent), allow.
+2. If the policy is `private`, reject with `ACCESS_DENIED` (403) unless 
+   the requesting actor is the authority itself.
+3. If the policy is `authenticated` or `capability`, decode any 
+   `Authorization: PhIP-Capability` header. If absent, reject with 
+   `MISSING_CAPABILITY` (403).
+4. Verify the token signature, expiry, and `granted_to` per Section 
+   11.3.4 steps 1–4.
+5. Verify the token's `scope` covers the requested operation:
+   - GET requires `read_state` or `read_history`
+   - GET history requires `read_history`
+   - QUERY requires `read_query`
+6. Verify the token's `object_filter` matches the target `phip_id`. For 
+   QUERY, the filter restricts which objects can be returned in the 
+   match list — objects outside the filter MUST be silently omitted, 
+   not returned with an error.
+7. If the policy is `capability`, verify the requesting actor matches 
+   `granted_to`.
+
+If any check fails, return `ACCESS_DENIED` (403) for policy mismatches 
+or `INVALID_CAPABILITY` (403) for token defects.
+
+#### 11.5.3 QUERY Filtering
+
+When QUERY is invoked without a token, the resolver MUST return only 
+objects whose policy is `public`. When invoked with a token, the 
+resolver MUST return only objects whose policy and ACL admit the 
+requesting actor. Restricted objects MUST NOT appear in the response — 
+omission is the only signal of inaccessibility.
+
+This means QUERY result counts depend on the caller's identity. 
+Resolvers SHOULD NOT advertise total counts that would leak the 
+existence of restricted objects.
+
+#### 11.5.4 Hash Chain Integrity Under Restriction
+
+A restricted object's hash chain remains valid for any party who can 
+read its history. The chain head MUST NOT be exposed via metadata 
+documents, error responses, or any other side channel that bypasses 
+the access policy. In particular, `CHAIN_CONFLICT` responses on PUSH 
+to a restricted object MUST NOT include `current_head` if the pushing 
+actor lacks a `read_state` or `read_history` scope; the resolver MUST 
+instead return `ACCESS_DENIED` (403) and require the pusher to obtain 
+read scope before retrying.
+
+#### 11.5.5 Public-By-Default Rationale
+
+PhIP keeps `public` as the default to preserve cross-organizational 
+discovery for regulatory disclosures, safety certifications, and 
+provenance claims that are intended to be verifiable by any party. 
+Authorities that hold commercially sensitive data MUST attach 
+`phip:access` explicitly — silence is consent.
 
 ---
 
@@ -1318,18 +2271,53 @@ structure is not normative.
 | `INVALID_SIGNATURE` | 401 | Event signature verification failed |
 | `KEY_NOT_FOUND` | 401 | The `key_id` in the signature could not be resolved |
 | `KEY_EXPIRED` | 401 | The signing key's validity window does not cover the event timestamp |
-| `MISSING_CAPABILITY` | 403 | Cross-org push without a capability token |
+| `MISSING_CAPABILITY` | 403 | Cross-org push or restricted read without a capability token |
 | `INVALID_CAPABILITY` | 403 | Capability token signature invalid, expired, or scope insufficient |
-| `FOREIGN_NAMESPACE` | 403 | CREATE attempted in a namespace the caller does not own |
+| `ACCESS_DENIED` | 403 | Read denied by the object's `phip:access` policy (Section 11.5) |
+| `FOREIGN_NAMESPACE` | 403 | CREATE attempted in a namespace the caller does not own, or `phip:access` write attempted from a foreign namespace |
 | `INVALID_OBJECT` | 422 | Object model validation failed (missing required fields, unknown type) |
 | `INVALID_EVENT` | 422 | Event structure invalid (missing fields, unknown event type) |
 | `INVALID_TRANSITION` | 422 | State transition not allowed on this object type's lifecycle track. `details` SHOULD include `valid_transitions` |
 | `INVALID_TRACK` | 422 | State is not valid for this object type's lifecycle track |
 | `INVALID_RELATION` | 422 | Relation type constraint violated (e.g., `located_at` target is not a `location` or `vehicle`) |
+| `DANGLING_RELATION` | 422 | A same-authority relation references a `phip_id` that does not exist (Section 7.4) |
 | `INVALID_QUERY` | 422 | Query predicate is malformed or uses unsupported features |
 
 Error responses MUST NOT be signed. They are informational, not 
 historical records. HTTPS is the integrity mechanism for error responses.
+
+### 12.6 Metadata Document
+
+An authority MAY publish a metadata document describing its resolver's
+capabilities:
+
+```
+GET https://{authority}/.well-known/phip/meta
+```
+
+A `200 OK` response is an `application/json` document with the following
+fields:
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `protocol_version` | string | MUST | Spec version this resolver targets (e.g. `"0.1.0-draft"`) |
+| `authority` | string | MUST | The authority name this resolver serves |
+| `namespaces` | array of strings | MUST | Namespaces this resolver will accept CREATEs into |
+| `schema_namespaces` | array of strings | SHOULD | Attribute namespaces whose schemas this resolver validates (e.g. `phip:mechanical`, `phip:software`) |
+| `supported_operations` | array of strings | SHOULD | Subset of `["create", "get", "push", "query", "history"]` |
+| `query_capabilities` | object | MAY | Optional map describing supported filter operators, glob syntax, sort orders |
+| `root_key` | string | SHOULD | PhIP URI of this authority's root key (Section 4.6.1). Clients use this to anchor trust for transfer verification |
+| `mirror_urls` | array of strings | MAY | URLs of read-only mirrors hosting frozen snapshots of this authority's records. See Section 4.6.5 |
+| `successor` | object | MAY | Present iff this authority has been transferred. Object: `{ "authority": "newco.example", "transfer_event_id": "...", "effective_from": "..." }`. Clients SHOULD redirect subsequent requests to the successor |
+| `delegations` | array of objects | MAY | Active sub-namespace delegations. See Section 4.5.1 for entry shape |
+
+A resolver that does not publish `/meta` is still conformant. Clients
+that need a feature not advertised in `/meta` SHOULD attempt the
+operation and handle the resulting error rather than refusing to
+connect.
+
+Servers responding to `/meta` SHOULD set `Cache-Control: public, max-age=3600`
+or longer — the document changes infrequently.
 
 ---
 
@@ -1368,7 +2356,24 @@ A conformant PhIP resolver SHOULD:
 - Support `Cache-Control` headers on key resource responses
 - Publish its supported schema namespaces
 
-[TODO: define a conformance test suite reference]
+A conformance test suite is maintained alongside this specification in the
+`tests/` directory of the reference repository. It has two independent
+components:
+
+- `tests/vectors/` — language-agnostic fixtures that lock down the wire
+  format: RFC 8785 canonicalization output, SHA-256 hash encoding,
+  Ed25519 signing and verification, URI parsing, hash-chain continuity,
+  lifecycle transition tables, and the self-signed bootstrap key pattern
+  (Section 11.2.4). A client library is byte-compatible with the reference
+  implementation iff it produces identical output on every fixture.
+
+- `tests/conformance/` — a black-box HTTP suite that exercises a running
+  PhIP server's `/.well-known/phip/*` endpoints through the full v0.1
+  contract: CREATE, GET, PUSH, QUERY, `/history/`, chain-conflict
+  handling, and error envelopes from Section 12.5.
+
+Compliant implementations SHOULD execute both components before publishing
+a release.
 
 ---
 
@@ -1391,7 +2396,145 @@ A conformant PhIP resolver SHOULD:
 
 ---
 
-## 15. IANA Considerations
+## 15. Privacy Considerations
+
+PhIP histories are append-only and signed. This is the right design for 
+provenance, but it sits in tension with privacy-by-design and with 
+data-protection regimes (GDPR, CCPA, PIPEDA, and similar) that grant 
+data subjects a right to erasure. PhIP does not solve this conflict; it 
+provides hooks that let an authority remain compliant by keeping 
+personal data **out of the chain in the first place**.
+
+**This section defines architectural conventions, not a compliance 
+framework.** Legal compliance is the authority's responsibility. PhIP's 
+job is to not prevent it.
+
+### 15.1 No Raw PII in Events
+
+A conformant authority MUST NOT place raw personal data in event 
+payloads. "Personal data" includes (non-exhaustively): names, email 
+addresses, postal addresses, phone numbers, government identifiers, 
+biometric data, precise geolocation, and any unique identifier that 
+maps directly to a natural person.
+
+Acceptable event metadata includes:
+
+- Actor URIs (`phip://acme.example/actors/operator-7421`) — these are 
+  pseudonymous identifiers under the authority's control and can be 
+  re-mapped or retired without rewriting history.
+- Timestamps, lifecycle states, lifecycle transitions, hash values.
+- Object-level attributes that describe the *thing*, not the person 
+  (serial numbers, dimensions, certifications).
+
+A `note` event payload of `"Inspected by Jane Doe at 555-1234"` is a 
+spec violation. The same information rendered as `"Inspected by 
+phip://acme.example/actors/inspector-jane-d"` is conformant.
+
+### 15.2 Personal Data Namespace Convention
+
+When an event MUST reference personal data — for traceability, 
+regulatory audit, or contractual obligation — the data MUST be carried 
+indirectly via the `phip:personal_data` attribute namespace.
+
+Values under `phip:personal_data` MUST be **commitments** (cryptographic 
+hashes with per-record salts), never raw values:
+
+```json
+{
+  "phip:personal_data": {
+    "subject_commitment": "sha256:c2b8d7e4...8f4a4e3c",
+    "salt_id": "salt-2026-04-001",
+    "data_class": "operator_identity",
+    "external_record": "phip://acme.example/records/operator-mapping-2026"
+  }
+}
+```
+
+| Field | Required | Description |
+|---|---|---|
+| `subject_commitment` | MUST | Salted hash of the personal data, encoded per Section 10.3 |
+| `salt_id` | MUST | Identifier of the salt used. Salts MUST be unique per record |
+| `data_class` | SHOULD | Free-text category (e.g. `operator_identity`, `customer_contact`) |
+| `external_record` | MAY | PhIP URI or URL of the off-chain record holding the raw data |
+
+Salts and the salt → raw-data mapping MUST be stored outside the PhIP 
+chain, in a system that supports deletion. Erasing a salt 
+cryptographically severs the commitment from any subject — the 
+commitment becomes an opaque hash with no recoverable original. This 
+is the spec's primary erasure mechanism: **delete the salt, and the 
+chain forgets.**
+
+### 15.3 External Record References
+
+When an event references off-chain data that is not itself personal 
+(e.g., a measurement file, an inspection photo, a contract PDF), the 
+reference SHOULD use the `phip:external_record` attribute namespace:
+
+```json
+{
+  "phip:external_record": {
+    "url": "https://records.acme.example/inspections/2026/04/INS-99421",
+    "content_hash": "sha256:8f4a4e3c...c2b8d7e4",
+    "media_type": "application/pdf",
+    "retention_policy": "7y"
+  }
+}
+```
+
+The `url` resolves through a system that supports deletion. The 
+`content_hash` lets the chain prove the referenced bytes existed at the 
+time of the event without storing them in the chain. After the 
+retention period elapses or a deletion request is honored, the URL may 
+return 404 — the chain remains valid but the referenced content is 
+gone.
+
+### 15.4 Pseudonymous Actors
+
+Authorities that process personal data SHOULD provision a separate 
+`actor` PhIP object per natural person rather than hard-coding 
+identifying strings into events. The actor's `identity` field MAY 
+contain personal data, but personal-data fields on actors are governed 
+by the same erasure mechanism: the authority deletes the actor's 
+external mapping and replaces the actor's `identity` block with a 
+sanitized projection (the historical events still reference the actor 
+URI but the URI no longer maps to a natural person).
+
+This approach trades exact replay fidelity for compliance: a verifier 
+can confirm "actor X signed this event in 2027" but cannot recover 
+which natural person actor X was, once the mapping is deleted.
+
+### 15.5 Salt Compromise
+
+If a salt itself leaks, every commitment using that salt becomes 
+opener and effectively reveals the underlying personal data. The 
+authority MUST treat salt compromise as a privacy incident and:
+
+1. Issue new salts for affected records going forward.
+2. Where contractual or legal duties require, notify affected subjects 
+   per the applicable regime (the spec does not define notification 
+   procedures).
+3. Update `phip:personal_data` attributes on subsequent events with the 
+   new salt; historical events using the leaked salt remain in the 
+   chain.
+
+A leaked salt cannot be "rotated out" of historical events — that is a 
+fundamental property of an append-only chain. The mitigation is 
+prospective. Authorities holding high-sensitivity data SHOULD generate 
+short-lifetime salts and rotate them on a schedule shorter than the 
+expected attack discovery window.
+
+### 15.6 Read Access Control as a Privacy Tool
+
+The `phip:access` mechanism (Section 11.5) is not by itself a privacy 
+control — restricting reads still leaves personal data in the chain 
+for the authority and any actor with read scope. Compliance regimes 
+generally require that personal data not exist in append-only form, 
+not merely that it be hidden from outside readers. Use Section 11.5 
+for confidentiality; use Section 15.1–15.5 for privacy.
+
+---
+
+## 16. IANA Considerations
 
 This document requests registration of the `phip` URI scheme.
 
@@ -1399,7 +2542,7 @@ This document requests registration of the `phip` URI scheme.
 
 ---
 
-## 16. References
+## 17. References
 
 ### Normative
 
@@ -1444,35 +2587,32 @@ Issues identified through scenario stress-testing and systematic review.
 | ~~A25~~ | Error response format | Standard error envelope with 17 error codes and HTTP status mappings. See Section 12.5 |
 | ~~A31~~ | Relation metadata | Optional flat `metadata` object on relations, carried through `relation_added` event payloads. See Section 7.2 |
 | ~~A32~~ | History pagination | GET returns state projection with `history_length`/`history_head`; separate `/history/` sub-resource with cursor pagination. See Section 12.2.1 |
+| ~~A10~~ | Resolver discovery, caching headers, redirect behavior | Authority name = DNS = HTTPS endpoint (no DNS TXT/SRV); `ETag`/`Cache-Control` guidance; same-authority-only redirect policy; `/.well-known/phip/meta` capability document. See Section 4.3 and Section 12.6 |
+| ~~A1~~ | Sub-object addressing: independent objects vs. facets | Field-replaceable rule, no lifecycle inheritance, `contained_in` is normative source of truth, path segments are informational. See Section 4.4 |
+| ~~A13~~ | Design revision model and `instance_of` target type | Added `design` object type (Section 6.2) on the manufacturing track; `instance_of` MUST target a `design`; `supersedes`/`superseded_by` relations link revisions. See Sections 6.2, 6.3, 7.1 |
+| ~~A23~~ | Authority transfer / domain death | New `authority_transfer` event type signed by a long-lived root authority key; authority record at `/.well-known/authority`; `mirror_urls` and `successor` fields in `/meta`; same-authority redirect rule relaxed for verified transfers. See Section 4.6 |
+| ~~A26~~ | No read access control | New `phip:access` namespace (`public`/`authenticated`/`capability`/`private`); capability tokens extended with `read_state`/`read_history`/`read_query` scopes; `ACCESS_DENIED` error code; QUERY filtering by access. See Section 11.5 and `schemas/access.json` |
+| ~~A27~~ | Privacy / GDPR | New Section 15 privacy annex: no-raw-PII rule, `phip:personal_data` salted-commitment convention, `phip:external_record` for off-chain references, salt deletion as the erasure mechanism, pseudonymous-actor pattern. See Section 15 |
+| ~~A2~~ | Proportional provenance: yield_fraction math | Yields constrained to [0,1]; sum-per-input ≤ 1 + ε with ε = 1e-6; missing fractions treated as unknown (no implicit equal-share); corrective process events for drift. See Section 10.4.1, 10.4.2 |
+| ~~A3~~ | Geographic position schema | New `phip:geo` namespace covering position (WGS 84 lat/lon/alt/accuracy), address, route with waypoints/carrier, and geofence. See `schemas/geo.json` |
+| ~~A4~~ | Cross-org custody transfer ownership | New Section 11.3.7: prior custodian → carrier → next custodian token chain with explicit pickup/transit/delivery roles and disruption handling. Sub-delegation requires direct issuance, not carrier re-delegation |
+| ~~A5~~ | Lot split mass conservation | New Section 10.5.1: `sum(resulting) ≤ source + ε` with optional `loss_quantity`; merge enforces equality; unit-mismatched merges require a `process` event |
+| ~~A6~~ | Measurement event payload | New Section 11.4.2: normative `metric`/`value`/`unit`/`as_of`/`method`/`uncertainty`/`thresholds`/`outcome`/`external_ref`/`samples` shape with derived-vs-raw distinction |
+| ~~A12~~ | Authority delegation | New Section 4.5.1–4.5.5: `delegations` array in `/meta`, scoped operations, revocation by metadata edit, sub-delegation depth control. Same-authority redirect rule relaxed for verified delegations |
+| ~~A14~~ | Lot fungibility | New Section 6.4: required `fungible` boolean on lot identity; non-fungible lots MUST `contains` member items; default-fungible if absent |
+| ~~A15~~ | Lot quantity tracking | New Section 6.4.1: `identity.quantity` with `value`/`unit`/`as_of`/`precision`; partial draw-down via `attribute_update` (no split needed); split is for new addressable sub-lots |
+| ~~A16~~ | Regulatory jurisdiction | Added `jurisdiction`, `regulatory_authority`, `applicable_jurisdictions`, and `export_control` (regime/classification/license) to `phip:compliance`. ISO 3166 codes |
+| ~~A18~~ | Uncertainty qualifiers | New Section 5.2.1: parallel `<field>_quality` convention with `confidence`/`source`/`as_of`/`corrected_from`/`note`. Tools MUST treat qualified and unqualified fields identically for matching |
+| ~~A29~~ | connected_to bidirectional cross-org | New Section 7.3: relations are owned by their writing object; `connected_to` and `contains`/`contained_in` only enforceable on the writing side; asymmetric relations MUST NOT be treated as proof of physical state |
+| ~~A30~~ | Dangling relations | New Section 7.4: graceful degradation rules + new `DANGLING_RELATION` (422) error code for same-authority broken refs only; cross-authority targets verified lazily by readers |
 
 ### A.2 Open Issues — Post-v0.1
 
-No issues currently block the reference implementation. The following 
-are real issues to address in subsequent spec revisions or appendices.
-
-These are real issues but do not block the reference implementation. 
-They can be addressed in subsequent spec revisions or appendices.
+No issues currently block the reference implementation. The remaining 
+items below are deferral candidates for v0.2.
 
 | # | Issue | Severity | Section |
 |---|---|---|---|
-| A1 | Sub-object addressing: path segments vs. fragment identifiers. Do sub-objects have independent lifecycle states? | High | 4.4 |
-| A13 | Design revision model and `design`/`specification` object type for `instance_of` targets | High | 6, 7 |
-| A23 | Authority transfer / domain death: no mechanism for ownership transfer or domain migration | High | 4.2 |
-| A26 | No read access control: trust model covers write authorization only. All objects publicly readable by default | High | 11, 12 |
-| A27 | Privacy / GDPR: append-only history conflicts with right-to-erasure. Standard mitigations (PII hashing, off-chain pointers) are well-understood — needs a privacy annex | High | 10, 14 |
-| A2 | Proportional provenance: `yield_fraction` math (conservation, rounding) needs normative rules | Medium | 10.4 |
-| A3 | Geographic position attribute schema for vehicles and mobile locations | Medium | 6.1 |
-| A4 | Cross-org relation write ownership during multi-party custody transfers | Medium | 11.3.1 |
-| A5 | Lot split mass conservation rules | Medium | 10.5 |
-| A6 | Measurement event payload format for referencing external telemetry | Medium | 11.4.1 |
-| A10 | Resolver discovery, caching headers, redirect behavior | Medium | 4.3 |
-| A12 | Authority delegation mechanism | Medium | 4.5 |
-| A14 | Fungibility flag for lot objects | Medium | 6 |
-| A15 | Quantity tracking on lots without lot splitting | Medium | 5, 10 |
-| A16 | Regulatory jurisdiction in compliance schema | Medium | 8.2 |
-| A18 | Uncertainty / confidence qualifiers on identity fields for legacy onboarding | Medium | 5.2 |
-| A29 | `connected_to` bidirectionality unenforceable cross-org | Medium | 7 |
-| A30 | Dangling relation references: guidance on unresolvable targets | Medium | 7 |
 | A33 | Batch/transaction operations for bulk object creation | Low | 12 |
 | A34 | Offline / air-gapped resolution | Low | 4.3 |
 | A35 | HTTP authentication mechanism | Low | 12 |

--- a/spec/phip-core.md
+++ b/spec/phip-core.md
@@ -183,7 +183,7 @@ Persistence of the URI is independent of persistence of the original
 authority's DNS record or operational organization. An authority that 
 ceases operation, is acquired, or migrates to a new domain transfers 
 its records via the mechanism in Section 4.6 (Authority Transfer). 
-Section 4.3.3 redirect rules and Section 12.6 metadata `mirror_urls` 
+Section 4.3.3 redirect rules and Section 12.7 metadata `mirror_urls` 
 provide the runtime mechanics for clients to follow such transfers.
 
 ### 4.3 Resolution
@@ -214,7 +214,7 @@ URI persistence (Section 4.2).
 An authority MAY publish a metadata document at
 `/.well-known/phip/meta` describing its supported protocol version,
 namespaces, and optional capabilities. The document format is defined in
-Section 12.6. Clients SHOULD fetch this document at most once per
+Section 12.7. Clients SHOULD fetch this document at most once per
 authority per session and cache it per the HTTP response headers.
 
 #### 4.3.2 Caching
@@ -278,6 +278,88 @@ MUST use `307` or `308` so the method and body are preserved.
 Clients SHOULD limit redirect chains to five hops and treat longer
 chains as a resolver misconfiguration (surface as a transport-layer
 error, not a PhIP error envelope).
+
+#### 4.3.4 Offline and Air-Gapped Resolution
+
+Some deployments resolve PhIP URIs without an internet connection: 
+factory floors with disconnected MES networks, military and aviation 
+maintenance environments, and supply-chain audits in remote 
+locations. PhIP supports these via two mechanisms — local cache 
+warm-up and signed bundle distribution.
+
+**Local cache warm-up.** A connected client populates its cache 
+(per §4.3.2) with the objects, key resources, and `/meta` 
+documents it expects to need, then disconnects. The cached 
+projections continue to verify against their hash chains and 
+signatures with no further network access. Reads against cached 
+objects work normally; writes are queued locally and replayed when 
+connectivity returns.
+
+The on-disk format for a warm cache is implementation-defined, but 
+clients SHOULD follow these constraints to maximize reuse:
+
+- Each cached object stored as the JCS-canonical bytes of its full 
+  state projection plus the JCS bytes of every event in its 
+  history.
+- Each cached key resource stored alongside the object whose 
+  signatures depend on it.
+- The cache index is keyed by `phip_id`.
+
+**Signed bundle distribution.** When a connected reference machine 
+needs to distribute records to a wholly disconnected site, the 
+authoritative wire format is a **PhIP bundle**: a signed archive 
+of one or more objects' states and histories. Bundle format:
+
+```
+phip-bundle.tar
+├── manifest.json          // bundle metadata + signature
+├── objects/
+│   ├── {urlencoded-phip-id-1}.json    // full object projection
+│   └── ...
+├── history/
+│   ├── {urlencoded-phip-id-1}.jsonl   // events in chain order, one per line
+│   └── ...
+└── keys/
+    └── {urlencoded-key-phip-id}.json  // key resources referenced by signatures
+```
+
+The `manifest.json` MUST contain:
+
+| Field | Required | Description |
+|---|---|---|
+| `bundle_version` | MUST | `"1.0"` |
+| `created_at` | MUST | ISO 8601 timestamp the bundle was assembled |
+| `created_by` | MUST | PhIP URI of the actor producing the bundle |
+| `authority` | MUST | Source authority name |
+| `objects` | MUST | Array of bundled `phip_id`s with `history_head` per object — bundle-level integrity manifest |
+| `signature` | MUST | Ed25519 signature over the JCS canonicalization of the manifest minus this field, signed by `created_by` |
+
+A consumer importing a bundle MUST:
+
+1. Verify the manifest signature against the producer's key 
+   resource (which MAY be embedded in `keys/`).
+2. For each object, verify the full hash chain from genesis to 
+   the manifest's claimed `history_head`.
+3. Verify each event signature against the corresponding key 
+   resource.
+4. Reject the bundle on any failure; do NOT partially apply.
+
+Bundles are append-only on the consumer side: importing the same 
+bundle twice is a no-op. Importing a bundle whose chain conflicts 
+with locally-held state MUST surface a `CHAIN_CONFLICT`-style error 
+to operators rather than overwriting silently.
+
+**Replay-on-reconnect.** A disconnected client that accepts local 
+PUSH operations buffers them as a queue. On reconnect, the client 
+replays the queue against the upstream resolver in order, handling 
+`CHAIN_CONFLICT` per §12.3.1 (re-fetch, re-sign, retry). The queue 
+SHOULD be persisted across client restarts; events MUST be replayed 
+in the order they were originally signed.
+
+Bundles, warm caches, and replay queues are all client-side 
+concerns. A resolver itself does not need to know whether its 
+clients are operating online or offline — the protocol is 
+indifferent.
 
 ### 4.4 Sub-Object Addressing
 
@@ -369,7 +451,7 @@ is a permanent cession.
 #### 4.5.1 Delegation Mechanism
 
 Delegation is recorded as an entry in the authority's metadata 
-document (§12.6) under a new `delegations` field:
+document (§12.7) under a new `delegations` field:
 
 ```json
 {
@@ -584,7 +666,7 @@ authority record before following the redirect.
 
 When the source authority is unreachable (DNS expiration, server 
 shutdown), clients fall back to mirrors listed in the successor's 
-metadata document (Section 12.6 `mirror_urls`). A mirror is a 
+metadata document (Section 12.7 `mirror_urls`). A mirror is a 
 read-only host serving a frozen snapshot of the source authority's 
 records as of `effective_from` (or a later snapshot if the source 
 continued to operate post-transfer).
@@ -1101,6 +1183,150 @@ org:droyd.com:teleop
 
 Custom namespace schemas SHOULD be published at a resolvable URL for 
 interoperability.
+
+### 8.4 Schema Versioning and Evolution
+
+Schemas evolve over time as domains add fields, refine vocabularies, 
+or correct mistakes. PhIP applies semantic versioning to schemas with 
+explicit rules about which changes are additive and which are 
+breaking.
+
+#### 8.4.1 Versioning Scheme
+
+Each schema version is identified by a semver string `MAJOR.MINOR`:
+
+- `MAJOR` increments on breaking changes — anything that could cause 
+  a previously-valid attribute block to be rejected by the new 
+  schema, or that would change the interpretation of existing 
+  fields.
+- `MINOR` increments on additive changes — new optional fields, new 
+  enum values, additional documentation.
+
+Patch numbers are not used; documentation-only changes do not 
+require a version bump (the schema content is unchanged).
+
+The version is encoded in the schema's `$id`:
+
+```
+https://github.com/mfgs-us/phip/schemas/mechanical/v1.2.json
+```
+
+The unversioned URL (`schemas/mechanical.json`) MUST resolve to the 
+latest stable version. Authorities that pin a specific version 
+SHOULD use the versioned URL.
+
+A schema's top-level `version` field carries the same string for 
+in-document reference:
+
+```json
+{
+  "$id": "...mechanical/v1.2.json",
+  "version": "1.2",
+  "title": "phip:mechanical",
+  ...
+}
+```
+
+#### 8.4.2 Additive Changes (MINOR bump)
+
+The following changes MAY be made within a MAJOR version:
+
+- Add a new OPTIONAL property.
+- Add a new value to an enum (existing values keep their meaning).
+- Tighten the description of an existing property without changing 
+  its validation rules.
+- Add a new pattern alternative to a `oneOf` schema.
+- Mark a field as `deprecated` (the field still validates; consumers 
+  are notified to migrate away).
+
+Implementations validating against an older MINOR version MUST still 
+accept attribute blocks that include newer optional fields — they 
+will simply ignore unknown properties (which is consistent with the 
+default `additionalProperties: true` of all PhIP core schemas).
+
+#### 8.4.3 Breaking Changes (MAJOR bump)
+
+The following changes REQUIRE a new MAJOR version:
+
+- Remove a property.
+- Rename a property (equivalent to remove + add).
+- Tighten validation: change a property from optional to required, 
+  add a new required property, narrow a numeric range, restrict an 
+  enum.
+- Change the type of a property.
+- Change the semantic meaning of a value (even if the type and 
+  validation are unchanged).
+
+A new MAJOR version is a new schema. Both versions remain published 
+at their respective `$id` URLs; the unversioned URL points at the 
+latest, but resolvers SHOULD continue to validate against older 
+versions for objects that were created against them.
+
+Authorities migrating data between MAJOR versions SHOULD record the 
+migration as an `attribute_update` event whose payload contains the 
+rewritten data; the historical events with the old shape remain in 
+the chain (consistent with §15's privacy framing — history is 
+append-only).
+
+#### 8.4.4 Schema Resolution
+
+When validating an attribute block, a resolver follows this 
+procedure:
+
+1. If the attribute block contains a `$schema` field, validate 
+   against that exact schema URL.
+2. Otherwise, look up the namespace (`phip:mechanical`) in the 
+   resolver's schema registry and validate against the latest 
+   MINOR version of the latest MAJOR version the registry holds.
+3. A `$schema` URL whose host or version is not in the registry 
+   MUST be fetched from its `$id` URL on first use; the resolver 
+   SHOULD cache fetched schemas with TTL guidance from the `/meta` 
+   document of the schema host.
+
+#### 8.4.5 Advertising Supported Schemas
+
+A resolver's `/meta` document (§12.7) lists supported schema 
+namespaces. To advertise version coverage, the entry MAY be a 
+string (latest MAJOR.MINOR supported) or an object listing the 
+exact range:
+
+```json
+{
+  "schema_namespaces": [
+    "phip:mechanical@1.2",
+    {
+      "namespace": "phip:datacenter",
+      "min": "1.0",
+      "max": "2.1"
+    },
+    "phip:software"
+  ]
+}
+```
+
+A bare namespace string (`"phip:software"`) means "latest version 
+the resolver supports, no range constraint advertised." Clients 
+SHOULD treat it as a soft signal only and rely on `$schema` URLs in 
+attribute blocks for authoritative version selection.
+
+#### 8.4.6 Compatibility Window
+
+Authorities SHOULD support at least one MAJOR version older than 
+the current one (i.e., N and N-1) for a minimum of 12 months after 
+N is released. This gives downstream consumers time to migrate 
+their writes. After the compatibility window, a resolver MAY 
+reject `attribute_update` events that target the deprecated MAJOR 
+version with `INVALID_OBJECT` (422), but it MUST continue to 
+serve historical events written against the deprecated version 
+unchanged.
+
+#### 8.4.7 Initial Versioning
+
+The schemas published with PhIP v0.1 are version `1.0`. The 
+versioning rules above apply prospectively — future schema 
+revisions move forward from 1.0. The unversioned URLs 
+(`schemas/mechanical.json` etc.) currently resolve to v1.0; when 
+v1.1 is published, they will resolve to v1.1.
 
 ---
 
@@ -2086,7 +2312,7 @@ The resolver MUST validate, in order:
 6. Object model constraints (relation type constraints, track validity)
 
 If validation fails at any step, the resolver MUST return the appropriate 
-error response (see Section 12.5) and MUST NOT append the event.
+error response (see Section 12.6) and MUST NOT append the event.
 
 Response: the appended event as stored. HTTP 201 on success.
 
@@ -2236,7 +2462,105 @@ QUERY does not require authentication by default — it returns the same
 objects that GET would return. Access control on QUERY results, if 
 implemented, SHOULD be consistent with access control on GET.
 
-### 12.5 Error Responses
+### 12.5 Batch Operations
+
+Resolvers MAY support batched CREATE and PUSH for bulk ingestion. 
+Batch endpoints exist as siblings to the single-event endpoints:
+
+```
+POST https://{authority}/.well-known/phip/objects/{namespace}/batch
+POST https://{authority}/.well-known/phip/push/{namespace}/batch
+```
+
+A resolver that supports batch operations MUST advertise it in the 
+`/meta` document via `supported_operations` containing the values 
+`"batch_create"` and/or `"batch_push"`.
+
+#### 12.5.1 Batch Request
+
+Request body is a JSON object with an `events` array. Each entry 
+is a complete signed event identical in shape to a single-event 
+CREATE or PUSH request.
+
+```json
+{
+  "events": [
+    { "event_id": "...", "phip_id": "phip://acme.example/parts/p-001", "type": "created", ... },
+    { "event_id": "...", "phip_id": "phip://acme.example/parts/p-002", "type": "created", ... },
+    { "event_id": "...", "phip_id": "phip://acme.example/parts/p-003", "type": "created", ... }
+  ]
+}
+```
+
+The batch MUST contain at most 1000 events. Resolvers MAY enforce a 
+lower limit and MUST advertise it via 
+`/meta.batch_max_events` (a positive integer, advisory).
+
+#### 12.5.2 Batch Semantics
+
+PhIP batches are **non-atomic**. Each event in the array is 
+processed independently — there is no all-or-nothing behavior 
+across the batch. This is consistent with the cross-namespace 
+atomicity deferral in §10.4: PhIP v0.1 does not provide 
+transactional guarantees.
+
+The resolver processes events in array order. For PUSH batches 
+targeting the same `phip_id`, this matters: each event in the 
+batch sees the chain head left by the previous event in the batch 
+(if it succeeded). For CREATE batches and PUSH batches targeting 
+different `phip_id`s, ordering is not significant for correctness.
+
+If an event fails (signature verification, chain conflict, schema 
+violation, etc.), the resolver MUST:
+
+- Record the failure in the response.
+- Continue processing subsequent events in the batch (not abort).
+- NOT roll back any successfully-processed events.
+
+If a downstream client requires atomicity, it MUST submit the 
+events one at a time and handle failures itself.
+
+#### 12.5.3 Batch Response
+
+The response is `200 OK` regardless of individual event outcomes 
+(the batch operation itself succeeded — its members may not 
+have). Body:
+
+```json
+{
+  "results": [
+    { "status": "created", "phip_id": "phip://acme.example/parts/p-001", "history_head": "sha256:..." },
+    { "status": "error", "phip_id": "phip://acme.example/parts/p-002", "error": { "code": "OBJECT_EXISTS", ... } },
+    { "status": "created", "phip_id": "phip://acme.example/parts/p-003", "history_head": "sha256:..." }
+  ],
+  "summary": { "total": 3, "succeeded": 2, "failed": 1 }
+}
+```
+
+Each entry in `results` corresponds positionally to the input 
+`events` array. Entries have:
+
+| Field | Required | Description |
+|---|---|---|
+| `status` | MUST | `"created"`, `"appended"`, or `"error"` |
+| `phip_id` | MUST | Object id the event targeted (echoed from the input) |
+| `history_head` | When status is created/appended | New chain head |
+| `error` | When status is error | Standard error envelope (§12.6) |
+
+The HTTP status code is `200 OK` if any event succeeded, `207 
+Multi-Status` if the batch contained successes and failures (RFC 
+4918 multi-status), or `400 Bad Request` if the batch envelope 
+itself is malformed (e.g., not a valid JSON object with an 
+`events` array). The batch MUST NOT return a 4xx/5xx status when 
+all member errors are per-event.
+
+#### 12.5.4 Batches Across Conformance Classes
+
+Read-Only and Mirror resolvers (§13.2, §13.3) MUST reject batch 
+endpoints with `405 WRITE_NOT_SUPPORTED` since they do not 
+implement writes.
+
+### 12.6 Error Responses
 
 All error responses MUST use `application/json` and the following format:
 
@@ -2282,11 +2606,12 @@ structure is not normative.
 | `INVALID_RELATION` | 422 | Relation type constraint violated (e.g., `located_at` target is not a `location` or `vehicle`) |
 | `DANGLING_RELATION` | 422 | A same-authority relation references a `phip_id` that does not exist (Section 7.4) |
 | `INVALID_QUERY` | 422 | Query predicate is malformed or uses unsupported features |
+| `WRITE_NOT_SUPPORTED` | 405 | Resolver does not accept writes (Read-Only or Mirror conformance class — Section 13.2/13.3) |
 
 Error responses MUST NOT be signed. They are informational, not 
 historical records. HTTPS is the integrity mechanism for error responses.
 
-### 12.6 Metadata Document
+### 12.7 Metadata Document
 
 An authority MAY publish a metadata document describing its resolver's
 capabilities:
@@ -2310,6 +2635,7 @@ fields:
 | `mirror_urls` | array of strings | MAY | URLs of read-only mirrors hosting frozen snapshots of this authority's records. See Section 4.6.5 |
 | `successor` | object | MAY | Present iff this authority has been transferred. Object: `{ "authority": "newco.example", "transfer_event_id": "...", "effective_from": "..." }`. Clients SHOULD redirect subsequent requests to the successor |
 | `delegations` | array of objects | MAY | Active sub-namespace delegations. See Section 4.5.1 for entry shape |
+| `conformance_class` | string | SHOULD | One of `full`, `read-only`, `mirror`, `client-only` (Section 13). Absence implies `full` for compatibility with v0.1 resolvers |
 
 A resolver that does not publish `/meta` is still conformant. Clients
 that need a feature not advertised in `/meta` SHOULD attempt the
@@ -2319,11 +2645,102 @@ connect.
 Servers responding to `/meta` SHOULD set `Cache-Control: public, max-age=3600`
 or longer — the document changes infrequently.
 
+### 12.8 HTTP Authentication
+
+PhIP defines exactly one wire-level authentication mechanism for 
+authorized operations:
+
+- `Authorization: PhIP-Capability <base64url-encoded-token>` — a 
+  signed capability token (§11.3). Used for cross-authority writes 
+  and for restricted reads (§11.5).
+
+This is the only authentication scheme that conformant resolvers 
+MUST recognize on protocol endpoints (`/.well-known/phip/objects`, 
+`/.well-known/phip/resolve`, `/.well-known/phip/push`, 
+`/.well-known/phip/query`, `/.well-known/phip/history`).
+
+#### 12.8.1 Transport Layer
+
+All PhIP traffic MUST be carried over TLS (§4.3 requires HTTPS for 
+the resolver endpoint). TLS provides confidentiality and integrity 
+for the request/response stream; PhIP signatures provide 
+authenticity for the events themselves.
+
+A resolver MAY require mutual TLS (mTLS) to its protocol endpoints 
+as an additional access control layer. mTLS is **transport-level** 
+authentication and operates orthogonally to PhIP-Capability tokens — 
+both can be required, neither replaces the other. A resolver that 
+uses mTLS:
+
+- MUST still validate any presented PhIP-Capability tokens per 
+  §11.3.4.
+- MUST NOT skip event signature verification on the basis of mTLS 
+  (the event signature is what writes into the chain; mTLS does 
+  not touch it).
+- SHOULD document its trust anchor in the `/meta` document under a 
+  new optional field:
+
+  | Field | Type | Description |
+  |---|---|---|
+  | `mtls_required` | boolean | If `true`, clients MUST present a TLS client certificate signed by an acceptable CA |
+  | `mtls_ca_bundle_url` | string | URL where the resolver publishes its CA bundle for client cert issuance |
+
+#### 12.8.2 Non-Protocol Endpoints
+
+Resolvers commonly expose endpoints outside `/.well-known/phip/` — 
+admin consoles, health checks, metrics, log shipping, replication. 
+These are not part of the PhIP wire contract. Resolvers MAY use any 
+appropriate authentication mechanism on them: HTTP Basic, OAuth 2.0 
+Bearer, session cookies, mTLS, etc. PhIP imposes no constraint on 
+non-protocol endpoint authentication.
+
+A resolver MUST NOT accept PhIP protocol writes on a non-protocol 
+endpoint to bypass capability-token enforcement. Operations that 
+modify chain state MUST go through the standard endpoints with 
+their standard authentication, regardless of how the operator 
+authenticates to the management plane.
+
+#### 12.8.3 Other Authentication Schemes
+
+PhIP v0.1 deliberately does NOT define:
+
+- HTTP Basic authentication for protocol endpoints.
+- OAuth 2.0 Bearer tokens for protocol endpoints.
+- API-key headers for protocol endpoints.
+
+Adding any of these would create ambiguity about which scheme 
+authoritatively identifies the writing actor — `granted_to` in a 
+PhIP-Capability is the only way an authority can verify the claim 
+chain back to its issuing key. A bearer token issued by some other 
+system cannot anchor the same chain of trust.
+
+Resolvers MAY accept these schemes for **read-only** operations on 
+**public** objects as a developer-convenience layer (e.g. an API 
+key gates access to a query endpoint without authorizing any 
+write), but MUST NOT route restricted reads (`phip:access` policy 
+not `public`) or any writes through them.
+
 ---
 
 ## 13. Conformance
 
-A conformant PhIP resolver MUST:
+PhIP defines four conformance classes. A resolver MUST claim exactly 
+one class in its `/meta` document via the `conformance_class` field 
+(see §12.7) and MUST satisfy that class's full requirement set.
+
+| Class | Operations | Use case |
+|---|---|---|
+| **Full** | CREATE, GET, PUSH, QUERY, history | A primary resolver — runs an authority's namespaces day-to-day |
+| **Read-Only** | GET, QUERY, history | Public-facing replica, reporting endpoint, regulator-facing portal |
+| **Mirror** | GET, history (frozen snapshot) | Archival mirror for a transferred or defunct authority (§4.6.5) |
+| **Client-Only** | None as server; consumes the protocol | A client library or application — does not host objects |
+
+The four classes share most requirements; they differ on which 
+operations they expose and on the strictness of certain checks.
+
+### 13.1 Full Resolver
+
+A Full resolver MUST:
 
 - Implement CREATE, GET (including history sub-resource), PUSH, and 
   QUERY operations
@@ -2342,19 +2759,93 @@ A conformant PhIP resolver MUST:
   `current_head` in error details (Section 12.3.1)
 - Verify and enforce capability tokens for cross-org writes, including 
   scope validation (Section 11.3)
-- Return standard error responses per Section 12.5
+- Return standard error responses per Section 12.6
 - Return objects in terminal states (`disposed`, `consumed`, `archived`) 
   on GET
 - Return `history_length` and `history_head` on GET responses
 - Support cursor pagination on history retrieval and QUERY responses
 
-A conformant PhIP resolver SHOULD:
+A Full resolver SHOULD:
 
 - Support the `depth` parameter on GET
 - Support the `at` parameter on GET for point-in-time queries
 - Validate condition values against the standard vocabulary
 - Support `Cache-Control` headers on key resource responses
 - Publish its supported schema namespaces
+
+### 13.2 Read-Only Resolver
+
+A Read-Only resolver MUST satisfy every requirement of a Full 
+resolver **except** the write operations. Specifically, it MUST:
+
+- Implement GET (including history sub-resource) and QUERY
+- Validate signatures and hash-chain integrity on served events
+- Return objects in terminal states unchanged
+- Return `history_length` and `history_head` on GET responses
+- Support cursor pagination
+
+A Read-Only resolver MUST reject CREATE and PUSH attempts with 
+`405 Method Not Allowed` (HTTP-level — there is no PhIP error code 
+for this case, since the server is not refusing on protocol grounds 
+but on capability). The response body SHOULD include an error 
+envelope with code `WRITE_NOT_SUPPORTED`:
+
+| Code | HTTP | Description |
+|---|---|---|
+| `WRITE_NOT_SUPPORTED` | 405 | Resolver does not accept writes (Read-Only or Mirror conformance class) |
+
+A Read-Only resolver SHOULD obtain its data by replication from a 
+Full resolver of the same authority. The replication mechanism is 
+out of scope for v0.1; the only normative requirement is that 
+served events MUST verify against the authority's keys.
+
+### 13.3 Mirror Resolver
+
+A Mirror resolver serves a frozen snapshot of another authority's 
+records (§4.6.5). It MUST:
+
+- Implement GET and history sub-resource only
+- Serve content under the **original** authority's URI namespace 
+  (`/.well-known/phip/resolve/...`), not its own
+- Set `Cache-Control: public, immutable` and a long `max-age` 
+  (≥ 1 year) on all responses
+- Decline QUERY with `405 WRITE_NOT_SUPPORTED` — query results 
+  against a mirror could go out of date silently as the mirror's 
+  index drifts; clients needing query MUST use the Full resolver 
+  or a Read-Only replica
+
+Mirror operators MUST publish their mirror URL in the source 
+authority's `/meta.mirror_urls` (§12.7) for discoverability.
+
+### 13.4 Client-Only Implementations
+
+A client library or end-user application that consumes PhIP but 
+does not host objects MUST:
+
+- Implement RFC 8785 (JCS) canonicalization producing byte-identical 
+  output to the test vectors (`tests/vectors/jcs/`)
+- Compute hashes per §10.3 (the `sha256:` + 64-hex form)
+- Sign and verify Ed25519 signatures per §11.1
+- Verify hash chains per §10.3 on read
+- Honor the same-authority redirect policy of §4.3.3 and the 
+  authority-transfer exception of §4.6.4
+
+A client-only implementation SHOULD pass `tests/vectors/self-check.js` 
+on its native runtime before being declared conformant.
+
+### 13.5 Cross-Class Notes
+
+Resolvers MAY change conformance class over their lifetime — for 
+example, a Full resolver becomes a Read-Only resolver when its 
+authority is transferred (§4.6) and writes are redirected. The 
+class change SHOULD be reflected in `/meta` and SHOULD trigger a 
+client-side cache invalidation.
+
+A resolver MUST NOT silently downgrade: if it stops accepting 
+writes, it MUST return `405 WRITE_NOT_SUPPORTED` rather than 
+appearing to accept them. Silent downgrade is a high-impact 
+failure mode that breaks chain integrity from the writer's 
+perspective.
 
 A conformance test suite is maintained alongside this specification in the
 `tests/` directory of the reference repository. It has two independent
@@ -2370,7 +2861,7 @@ components:
 - `tests/conformance/` — a black-box HTTP suite that exercises a running
   PhIP server's `/.well-known/phip/*` endpoints through the full v0.1
   contract: CREATE, GET, PUSH, QUERY, `/history/`, chain-conflict
-  handling, and error envelopes from Section 12.5.
+  handling, and error envelopes from Section 12.6.
 
 Compliant implementations SHOULD execute both components before publishing
 a release.
@@ -2584,10 +3075,10 @@ Issues identified through scenario stress-testing and systematic review.
 | ~~A9~~ | Query predicate grammar | Field, attribute, and relation filters with glob syntax, two return modes, cursor pagination. See Section 12.4 |
 | ~~A11~~ | Capability token mechanics | `PhIP-Capability` HTTP header, four scope levels, token format with verification steps, short-lived tokens with expiry-based revocation. See Section 11.3 |
 | ~~A24~~ | Concurrency | Optimistic locking: PUSH requires `previous_hash` match, 409 `CHAIN_CONFLICT` on mismatch, client re-fetches/re-signs/retries. See Section 12.3.1 |
-| ~~A25~~ | Error response format | Standard error envelope with 17 error codes and HTTP status mappings. See Section 12.5 |
+| ~~A25~~ | Error response format | Standard error envelope with 17 error codes and HTTP status mappings. See Section 12.6 |
 | ~~A31~~ | Relation metadata | Optional flat `metadata` object on relations, carried through `relation_added` event payloads. See Section 7.2 |
 | ~~A32~~ | History pagination | GET returns state projection with `history_length`/`history_head`; separate `/history/` sub-resource with cursor pagination. See Section 12.2.1 |
-| ~~A10~~ | Resolver discovery, caching headers, redirect behavior | Authority name = DNS = HTTPS endpoint (no DNS TXT/SRV); `ETag`/`Cache-Control` guidance; same-authority-only redirect policy; `/.well-known/phip/meta` capability document. See Section 4.3 and Section 12.6 |
+| ~~A10~~ | Resolver discovery, caching headers, redirect behavior | Authority name = DNS = HTTPS endpoint (no DNS TXT/SRV); `ETag`/`Cache-Control` guidance; same-authority-only redirect policy; `/.well-known/phip/meta` capability document. See Section 4.3 and Section 12.7 |
 | ~~A1~~ | Sub-object addressing: independent objects vs. facets | Field-replaceable rule, no lifecycle inheritance, `contained_in` is normative source of truth, path segments are informational. See Section 4.4 |
 | ~~A13~~ | Design revision model and `instance_of` target type | Added `design` object type (Section 6.2) on the manufacturing track; `instance_of` MUST target a `design`; `supersedes`/`superseded_by` relations link revisions. See Sections 6.2, 6.3, 7.1 |
 | ~~A23~~ | Authority transfer / domain death | New `authority_transfer` event type signed by a long-lived root authority key; authority record at `/.well-known/authority`; `mirror_urls` and `successor` fields in `/meta`; same-authority redirect rule relaxed for verified transfers. See Section 4.6 |
@@ -2605,19 +3096,16 @@ Issues identified through scenario stress-testing and systematic review.
 | ~~A18~~ | Uncertainty qualifiers | New Section 5.2.1: parallel `<field>_quality` convention with `confidence`/`source`/`as_of`/`corrected_from`/`note`. Tools MUST treat qualified and unqualified fields identically for matching |
 | ~~A29~~ | connected_to bidirectional cross-org | New Section 7.3: relations are owned by their writing object; `connected_to` and `contains`/`contained_in` only enforceable on the writing side; asymmetric relations MUST NOT be treated as proof of physical state |
 | ~~A30~~ | Dangling relations | New Section 7.4: graceful degradation rules + new `DANGLING_RELATION` (422) error code for same-authority broken refs only; cross-authority targets verified lazily by readers |
+| ~~A33~~ | Batch operations | New Section 12.5: non-atomic `/objects/{ns}/batch` and `/push/{ns}/batch` endpoints with per-event results, 1000-event cap, advertised via `supported_operations` in `/meta`. Read-Only/Mirror resolvers reject with `WRITE_NOT_SUPPORTED` |
+| ~~A34~~ | Offline / air-gapped resolution | New Section 4.3.4: warm cache, signed PhIP bundle format (manifest + objects + history + keys), full chain verification on import, replay-on-reconnect with `CHAIN_CONFLICT` handling |
+| ~~A35~~ | HTTP authentication | New Section 12.8: PhIP-Capability is the only protocol-level auth scheme; mTLS is a transport overlay (does not replace event signatures); non-protocol endpoints free to use any scheme; basic/bearer/API-key MUST NOT route restricted reads or writes |
+| ~~A36~~ | Conformance levels | Section 13 restructured into four classes (Full / Read-Only / Mirror / Client-Only); new `WRITE_NOT_SUPPORTED` (405) error code; new `conformance_class` field in `/meta` |
+| ~~A37~~ | Schema versioning | New Section 8.4: semver MAJOR.MINOR with explicit additive vs. breaking change rules, versioned `$id` URLs, `version` field in schemas (all v0.1 schemas seeded at 1.0), advertise via `/meta.schema_namespaces`, 12-month minimum compatibility window |
 
 ### A.2 Open Issues — Post-v0.1
 
-No issues currently block the reference implementation. The remaining 
-items below are deferral candidates for v0.2.
-
-| # | Issue | Severity | Section |
-|---|---|---|---|
-| A33 | Batch/transaction operations for bulk object creation | Low | 12 |
-| A34 | Offline / air-gapped resolution | Low | 4.3 |
-| A35 | HTTP authentication mechanism | Low | 12 |
-| A36 | Conformance levels (read-only resolvers) | Low | 13 |
-| A37 | Schema versioning and evolution strategy | Low | 8 |
+All issues identified through v0.1 stress-testing are resolved. Future 
+revisions will add issues as they surface.
 
 ---
 

--- a/spec/phip-core.md
+++ b/spec/phip-core.md
@@ -45,8 +45,9 @@ Breaking changes are expected before v1.0.0.
 12. Protocol Operations
 13. Conformance
 14. Security Considerations
-15. IANA Considerations
-16. References
+15. Privacy Considerations
+16. IANA Considerations
+17. References
 Appendix A. Open Issues
 
 ---
@@ -497,8 +498,28 @@ SHOULD:
 4. Cache the delegation per `Cache-Control` headers; re-fetch on 
    `effective_from`/`expires` boundary or on cache invalidation.
 
-The same-authority redirect rule (§4.3.3) is relaxed for verified 
-delegations, by analogy to the transfer exception.
+**Delegation redirect mechanics.** The same-authority redirect rule 
+of §4.3.3 has a second exception (the first being authority transfer 
+in §4.6.4): a redirect from the parent authority to the delegate 
+authority is permitted iff it is justified by an active delegation 
+entry covering the requested namespace and prefix. The redirect 
+response MUST include a `PhIP-Delegation: <namespace>` header naming 
+the parent's namespace whose delegation justifies the cross-authority 
+hop. Clients receiving such a redirect MUST:
+
+1. Fetch the parent's `/meta` document if not already cached.
+2. Locate a `delegations` entry whose `namespace`, optional `prefix`, 
+   and `effective_from`/`expires` window cover the request.
+3. Verify the entry's `delegate_authority` matches the redirect 
+   target's host and the entry's `scope` includes the operation 
+   being attempted.
+4. If any check fails, treat the redirect as if it crossed authority 
+   boundaries without justification — abort the request and surface 
+   a transport-layer error (§4.3.3).
+
+A `PhIP-Delegation` header without a corresponding `delegations` entry 
+in the parent's `/meta` MUST be treated as if absent. Clients MUST 
+NOT follow the redirect on faith.
 
 #### 4.5.3 Writes Under Delegation
 
@@ -957,6 +978,26 @@ authority SHOULD emit an `attribute_update` event reducing
 maintain a `contains` relation to every member, since the count is 
 derivable. Authorities MAY include it anyway for query convenience.
 
+##### 6.4.1.1 Shorthand Form in Event Payloads
+
+Event payloads (`lot_split`, `lot_merge`, and ad-hoc `attribute_update`
+content) MAY use a flat shorthand for terseness: a single `quantity_<unit>`
+key carrying just the numeric value. The shorthand `quantity_kg: 12000`
+is equivalent to the structured form `quantity: { value: 12000, unit: "kg" }`.
+The mapping is purely lexical — `quantity_<unit>` SHALL be parsed as
+`{ value: <number>, unit: "<unit>" }`.
+
+The shorthand exists because lot event payloads commonly inline many 
+quantities and the structured form bloats them. Outside of event 
+payloads — including the lot's `identity.quantity` projection — the 
+structured form is the canonical representation. Resolvers projecting 
+shorthand into `identity.quantity` MUST emit the structured form.
+
+When a payload uses shorthand, all quantities in that payload MUST 
+share the same unit; mixed-unit shorthand (`quantity_kg` next to 
+`quantity_units` in the same payload) is invalid. The `loss_quantity_<unit>`
+form follows the same rule.
+
 ---
 
 ## 7. Relation Vocabulary
@@ -975,7 +1016,7 @@ PhIP Objects. Each relation is a tuple of (type, phip_id).
 | `replaces` | `replaced_by` | Temporal substitution. Subject took the place of object |
 | `instance_of` | — | Subject is a physical instance of a design. Target MUST be of type `design` (Section 6.3) |
 | `supersedes` | `superseded_by` | Subject `design` revision replaces an older `design`. Both endpoints MUST be of type `design` |
-| `manufactured_by` | — | Object MUST be of type `actor` |
+| `manufactured_by` | — | Subject was produced by the object. Object MUST be of type `actor` |
 
 ### 7.2 Relation Format
 
@@ -1692,8 +1733,6 @@ instead, since unit conversion is a transformation.
 The `source_lots` array MUST contain at least two entries. Each source 
 lot SHOULD be transitioned to `consumed` by the pushing actor.
 
-[TODO: define whether lot splits require equal mass conservation]
-
 ---
 
 ## 11. Trust Model
@@ -2084,8 +2123,16 @@ read access by attaching a `phip:access` attribute to an object.
 
 #### 11.5.1 Access Policy
 
-The `phip:access` attribute namespace defines a single field, `policy`,
-whose value is one of:
+The `phip:access` attribute namespace defines the following fields:
+
+| Field | Required | Description |
+|---|---|---|
+| `policy` | MUST | One of `public`, `authenticated`, `capability`, `private` (table below) |
+| `policy_set_by` | MAY | PhIP URI of the actor who applied the current policy. Informational; the authoritative record is the event history |
+| `policy_set_at` | MAY | ISO 8601 timestamp the current policy was applied |
+| `rationale` | MAY | Human-readable note explaining the policy choice (e.g., "customer BOM under NDA", "public regulatory disclosure") |
+
+`policy` values:
 
 | Policy | Meaning |
 |---|---|
@@ -2323,6 +2370,15 @@ appended strictly sequentially. If two actors push events concurrently,
 both will compute `previous_hash` from the same chain head. The first 
 push succeeds; the second MUST be rejected with a `CHAIN_CONFLICT` error.
 
+`CHAIN_CONFLICT` responses MUST include `current_head` in `details`, so 
+the rejected client can re-sign and retry without an additional GET. 
+The one exception is the read-access carve-out in §11.5.4: when the 
+target object is restricted and the pushing actor lacks read scope, 
+the resolver MUST suppress `current_head` and return `ACCESS_DENIED` 
+(403) instead of `CHAIN_CONFLICT` (409). The pusher must obtain read 
+scope before they can recover. §11.5.4 is the only condition under 
+which `current_head` is withheld.
+
 The rejected client MUST:
 
 1. Re-fetch the object to obtain the new `history_head`
@@ -2547,17 +2603,26 @@ Each entry in `results` corresponds positionally to the input
 | `history_head` | When status is created/appended | New chain head |
 | `error` | When status is error | Standard error envelope (§12.6) |
 
-The HTTP status code is `200 OK` if any event succeeded, `207 
-Multi-Status` if the batch contained successes and failures (RFC 
-4918 multi-status), or `400 Bad Request` if the batch envelope 
-itself is malformed (e.g., not a valid JSON object with an 
-`events` array). The batch MUST NOT return a 4xx/5xx status when 
-all member errors are per-event.
+The HTTP status code is determined by the **distribution** of per-event 
+outcomes, not by their absolute count:
+
+| Outcome | HTTP status |
+|---|---|
+| All events in the batch succeeded | `200 OK` |
+| Batch contains both successes and failures | `207 Multi-Status` (RFC 4918) |
+| Every event in the batch failed | `422 Unprocessable Content` |
+| Batch envelope itself is malformed (not a JSON object with an `events` array, or `events` exceeds the resolver's maximum) | `400 Bad Request` |
+
+The 200 / 207 / 422 cases all return the body shape above; only the 
+400 case returns a top-level error envelope (§12.6) without a 
+`results` array. The batch operation itself does not produce a 5xx 
+status when failures are per-event — 5xx is reserved for actual 
+resolver-side problems.
 
 #### 12.5.4 Batches Across Conformance Classes
 
 Read-Only and Mirror resolvers (§13.2, §13.3) MUST reject batch 
-endpoints with `405 WRITE_NOT_SUPPORTED` since they do not 
+endpoints with `405 OPERATION_NOT_SUPPORTED` since they do not 
 implement writes.
 
 ### 12.6 Error Responses
@@ -2583,13 +2648,13 @@ The `message` field is a human-readable description. The `details` field
 is OPTIONAL and carries error-code-specific context for debugging; its 
 structure is not normative.
 
-#### 12.5.1 Error Code Registry
+#### 12.6.1 Error Code Registry
 
 | Code | HTTP Status | Description |
 |---|---|---|
 | `OBJECT_NOT_FOUND` | 404 | GET or PUSH to a non-existent PhIP ID |
 | `OBJECT_EXISTS` | 409 | CREATE with a `phip_id` that is already registered |
-| `CHAIN_CONFLICT` | 409 | PUSH `previous_hash` does not match current chain head. `details` MUST include `current_head` |
+| `CHAIN_CONFLICT` | 409 | PUSH `previous_hash` does not match current chain head. `details` MUST include `current_head`, except as carved out by §11.5.4 (restricted-read access) |
 | `DUPLICATE_EVENT` | 409 | An event with this `event_id` already exists (replay protection) |
 | `TERMINAL_STATE` | 409 | Object is in a terminal state and cannot accept events |
 | `INVALID_SIGNATURE` | 401 | Event signature verification failed |
@@ -2606,7 +2671,7 @@ structure is not normative.
 | `INVALID_RELATION` | 422 | Relation type constraint violated (e.g., `located_at` target is not a `location` or `vehicle`) |
 | `DANGLING_RELATION` | 422 | A same-authority relation references a `phip_id` that does not exist (Section 7.4) |
 | `INVALID_QUERY` | 422 | Query predicate is malformed or uses unsupported features |
-| `WRITE_NOT_SUPPORTED` | 405 | Resolver does not accept writes (Read-Only or Mirror conformance class — Section 13.2/13.3) |
+| `OPERATION_NOT_SUPPORTED` | 405 | Resolver does not implement the requested operation under its declared conformance class (Section 13). Examples: writes against a Read-Only or Mirror resolver, QUERY against a Mirror resolver |
 
 Error responses MUST NOT be signed. They are informational, not 
 historical records. HTTPS is the integrity mechanism for error responses.
@@ -2756,7 +2821,8 @@ A Full resolver MUST:
   event timestamps
 - Maintain hash chain integrity per RFC 8785 (JCS) serialization
 - Return `CHAIN_CONFLICT` (409) on concurrent push conflicts with 
-  `current_head` in error details (Section 12.3.1)
+  `current_head` in error details, subject to the §11.5.4 read-access 
+  carve-out (Section 12.3.1)
 - Verify and enforce capability tokens for cross-org writes, including 
   scope validation (Section 11.3)
 - Return standard error responses per Section 12.6
@@ -2788,11 +2854,11 @@ A Read-Only resolver MUST reject CREATE and PUSH attempts with
 `405 Method Not Allowed` (HTTP-level — there is no PhIP error code 
 for this case, since the server is not refusing on protocol grounds 
 but on capability). The response body SHOULD include an error 
-envelope with code `WRITE_NOT_SUPPORTED`:
+envelope with code `OPERATION_NOT_SUPPORTED`:
 
 | Code | HTTP | Description |
 |---|---|---|
-| `WRITE_NOT_SUPPORTED` | 405 | Resolver does not accept writes (Read-Only or Mirror conformance class) |
+| `OPERATION_NOT_SUPPORTED` | 405 | Resolver does not implement the requested operation under its declared conformance class |
 
 A Read-Only resolver SHOULD obtain its data by replication from a 
 Full resolver of the same authority. The replication mechanism is 
@@ -2809,7 +2875,7 @@ records (§4.6.5). It MUST:
   (`/.well-known/phip/resolve/...`), not its own
 - Set `Cache-Control: public, immutable` and a long `max-age` 
   (≥ 1 year) on all responses
-- Decline QUERY with `405 WRITE_NOT_SUPPORTED` — query results 
+- Decline QUERY with `405 OPERATION_NOT_SUPPORTED` — query results 
   against a mirror could go out of date silently as the mirror's 
   index drifts; clients needing query MUST use the Full resolver 
   or a Read-Only replica
@@ -2830,8 +2896,11 @@ does not host objects MUST:
 - Honor the same-authority redirect policy of §4.3.3 and the 
   authority-transfer exception of §4.6.4
 
-A client-only implementation SHOULD pass `tests/vectors/self-check.js` 
-on its native runtime before being declared conformant.
+A client-only implementation SHOULD reproduce every fixture in 
+`tests/vectors/` from its native runtime before being declared 
+conformant. The HTTP suite at `tests/conformance/` does not apply 
+to client-only implementations — the conformance suite exercises 
+server endpoints, which clients do not host.
 
 ### 13.5 Cross-Class Notes
 
@@ -2842,7 +2911,7 @@ class change SHOULD be reflected in `/meta` and SHOULD trigger a
 client-side cache invalidation.
 
 A resolver MUST NOT silently downgrade: if it stops accepting 
-writes, it MUST return `405 WRITE_NOT_SUPPORTED` rather than 
+writes, it MUST return `405 OPERATION_NOT_SUPPORTED` rather than 
 appearing to accept them. Silent downgrade is a high-impact 
 failure mode that breaks chain integrity from the writer's 
 perspective.
@@ -3096,10 +3165,10 @@ Issues identified through scenario stress-testing and systematic review.
 | ~~A18~~ | Uncertainty qualifiers | New Section 5.2.1: parallel `<field>_quality` convention with `confidence`/`source`/`as_of`/`corrected_from`/`note`. Tools MUST treat qualified and unqualified fields identically for matching |
 | ~~A29~~ | connected_to bidirectional cross-org | New Section 7.3: relations are owned by their writing object; `connected_to` and `contains`/`contained_in` only enforceable on the writing side; asymmetric relations MUST NOT be treated as proof of physical state |
 | ~~A30~~ | Dangling relations | New Section 7.4: graceful degradation rules + new `DANGLING_RELATION` (422) error code for same-authority broken refs only; cross-authority targets verified lazily by readers |
-| ~~A33~~ | Batch operations | New Section 12.5: non-atomic `/objects/{ns}/batch` and `/push/{ns}/batch` endpoints with per-event results, 1000-event cap, advertised via `supported_operations` in `/meta`. Read-Only/Mirror resolvers reject with `WRITE_NOT_SUPPORTED` |
+| ~~A33~~ | Batch operations | New Section 12.5: non-atomic `/objects/{ns}/batch` and `/push/{ns}/batch` endpoints with per-event results, 1000-event cap, advertised via `supported_operations` in `/meta`. Read-Only/Mirror resolvers reject with `OPERATION_NOT_SUPPORTED` |
 | ~~A34~~ | Offline / air-gapped resolution | New Section 4.3.4: warm cache, signed PhIP bundle format (manifest + objects + history + keys), full chain verification on import, replay-on-reconnect with `CHAIN_CONFLICT` handling |
 | ~~A35~~ | HTTP authentication | New Section 12.8: PhIP-Capability is the only protocol-level auth scheme; mTLS is a transport overlay (does not replace event signatures); non-protocol endpoints free to use any scheme; basic/bearer/API-key MUST NOT route restricted reads or writes |
-| ~~A36~~ | Conformance levels | Section 13 restructured into four classes (Full / Read-Only / Mirror / Client-Only); new `WRITE_NOT_SUPPORTED` (405) error code; new `conformance_class` field in `/meta` |
+| ~~A36~~ | Conformance levels | Section 13 restructured into four classes (Full / Read-Only / Mirror / Client-Only); new `OPERATION_NOT_SUPPORTED` (405) error code; new `conformance_class` field in `/meta` |
 | ~~A37~~ | Schema versioning | New Section 8.4: semver MAJOR.MINOR with explicit additive vs. breaking change rules, versioned `$id` URLs, `version` field in schemas (all v0.1 schemas seeded at 1.0), advertise via `/meta.schema_namespaces`, 12-month minimum compatibility window |
 
 ### A.2 Open Issues — Post-v0.1

--- a/spec/phip-core.md
+++ b/spec/phip-core.md
@@ -2578,9 +2578,9 @@ events one at a time and handle failures itself.
 
 #### 12.5.3 Batch Response
 
-The response is `200 OK` regardless of individual event outcomes 
-(the batch operation itself succeeded — its members may not 
-have). Body:
+The response body shape is the same regardless of individual event 
+outcomes; the HTTP status code reflects the distribution per the 
+table below. Body:
 
 ```json
 {

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,46 @@
+# PhIP Tests
+
+Interop prerequisites for client-library implementations (`phip-js`,
+`phip-py`, and any other language).
+
+## Structure
+
+* [`vectors/`](./vectors/) — language-agnostic fixtures. Any client library
+  that produces byte-identical output on these inputs is wire-compatible
+  with the reference implementation. Covers JCS canonicalization, SHA-256
+  hashing, Ed25519 sign/verify, URI parsing, hash-chain continuity,
+  lifecycle transitions, and the self-signed bootstrap key pattern.
+
+* [`conformance/`](./conformance/) — black-box HTTP suite for PhIP servers.
+  Runs CREATE, GET, PUSH, QUERY, `/history/`, and error-envelope tests
+  against any server under `/.well-known/phip/*`.
+
+## Installation
+
+```
+npm install
+```
+
+## Running
+
+Regenerate the vectors and verify their internal consistency:
+
+```
+npm run generate
+npm run self-check
+```
+
+Run the HTTP conformance suite against a server:
+
+```
+npm run conformance -- http://127.0.0.1:8080 --authority example.com
+```
+
+## Why these exist
+
+Without shared fixtures and an HTTP-level conformance suite, two
+independently written client libraries will each pass their own tests
+while silently disagreeing on the wire — different key orderings in JCS,
+different signature encodings, different error codes. These tests lock
+down the wire contract so that `phip-js` and `phip-py` can be trusted to
+talk to the same server and see the same bytes.

--- a/tests/conformance/README.md
+++ b/tests/conformance/README.md
@@ -1,0 +1,64 @@
+# PhIP HTTP Conformance Suite
+
+A black-box test suite for PhIP servers. Any implementation that passes this
+suite against an empty namespace is wire-compatible with the reference
+resolver for the v0.1 scope: CREATE, GET, PUSH, QUERY, `/history/`, and
+error envelopes.
+
+## Usage
+
+```
+node conformance/run.js <base-url> [--namespace <ns>] [--authority <auth>]
+```
+
+Example against a local reference server bound to `acme.example`:
+
+```
+PHIP_AUTHORITY=acme.example PHIP_PORT=8080 node reference/src/index.js &
+node conformance/run.js http://127.0.0.1:8080 --authority acme.example
+```
+
+* `<base-url>` — where the server is reachable over HTTP(S).
+* `--authority` — the PhIP authority the server is bound to. Defaults to
+  the hostname from `<base-url>`. Override when the network address and the
+  logical authority differ (reverse proxies, port forwarding, test harnesses).
+* `--namespace` — the namespace to create objects under. Defaults to
+  `conformance`.
+
+Each run generates a fresh 8-character run-id and suffixes every object id
+with it, so the suite can be executed repeatedly against the same server
+without CREATE collisions.
+
+## What it tests
+
+| # | Section  | Behaviour                                                   |
+|---|----------|-------------------------------------------------------------|
+| 1 | 11.2.4   | Self-signed bootstrap actor CREATE                          |
+| 2 | 12.1     | CREATE component in concept state                           |
+| 3 | 12.2     | GET projects `phip_id`, `state`, `history_length`, head     |
+| 4 | 12.3, 9  | PUSH `state_transition` concept → design                    |
+| 5 | 12.3     | PUSH `attribute_update` into `phip:software`                |
+| 6 | 9.2.1    | Invalid transition rejected with `INVALID_TRANSITION`       |
+| 7 | 12.3.1   | Stale `previous_hash` → 409 `CHAIN_CONFLICT` with head      |
+| 8 | 12.2.1   | `/history/` returns all events with verifiable chain        |
+| 9 | 12.4     | QUERY by `object_type` and by `state`                       |
+| 10| 12.5     | `OBJECT_NOT_FOUND`, `OBJECT_EXISTS` envelopes               |
+
+The suite signs all events with the first fixed Ed25519 keypair from
+`vectors/ed25519/keypair.json` — the server therefore only needs to verify
+signatures, not hold any credentials of its own.
+
+## Out of scope for v0.1
+
+* Cross-authority GET (resolver discovery — Section 4.3, currently `[TODO]`)
+* Capability tokens (Section 11.3) — v0 is intra-namespace only
+* Pagination cursor behaviour past 100 events
+* Archived-state `note`-only acceptance — added once operational-track
+  CREATE is exercised
+
+## Interpreting failures
+
+When an assertion fails, the suite prints the failing check with a short
+detail (often the unexpected status or error code). The harness is
+intentionally minimal — a failure means the server diverges from the spec
+in a way that would break client-library interop.

--- a/tests/conformance/run.js
+++ b/tests/conformance/run.js
@@ -1,0 +1,400 @@
+// PhIP HTTP conformance suite.
+//
+// Exercises any PhIP server over HTTPS (or HTTP) to verify it implements the
+// wire contract from phip-core.md Sections 4, 10, 11, 12. This is a
+// black-box test — the server must only expose the standard endpoints under
+// /.well-known/phip/.
+//
+// Usage:   node conformance/run.js <base-url> [namespace]
+// Example: node conformance/run.js http://localhost:3000 conformance
+//
+// The suite creates a self-signed bootstrap actor, then a component object,
+// pushes state transitions and attribute updates, reads history, runs
+// queries, and asserts error envelopes. All object ids are suffixed with a
+// random run-id so the suite is safe to run repeatedly against the same
+// server.
+
+"use strict";
+
+const crypto = require("node:crypto");
+const http = require("node:http");
+const https = require("node:https");
+const path = require("node:path");
+const fs = require("node:fs");
+const canonicalize = require("canonicalize");
+
+// Parse argv: base-url is positional; namespace and authority can be
+// positional or passed as --flag. Authority defaults to the URL hostname but
+// MUST be overridable because PhIP authorities are names, not network
+// addresses — a server bound to authority "acme.example" can be reached at
+// http://localhost:8080 during testing.
+const raw = process.argv.slice(2);
+let BASE_URL = null;
+let NAMESPACE = "conformance";
+let AUTHORITY_OVERRIDE = null;
+for (let i = 0; i < raw.length; i++) {
+  const a = raw[i];
+  if (a === "--namespace") NAMESPACE = raw[++i];
+  else if (a === "--authority") AUTHORITY_OVERRIDE = raw[++i];
+  else if (!BASE_URL) BASE_URL = a;
+  else NAMESPACE = a;
+}
+if (!BASE_URL) {
+  console.error(
+    "usage: node conformance/run.js <base-url> [--namespace <ns>] [--authority <auth>]"
+  );
+  process.exit(2);
+}
+
+const RUN_ID = crypto.randomBytes(4).toString("hex");
+const KEY_LOCAL_ID = `keys/bootstrap-${RUN_ID}`;
+const OBJ_LOCAL_ID = `units/${RUN_ID}`;
+const AUTHORITY = AUTHORITY_OVERRIDE || new URL(BASE_URL).host.split(":")[0];
+const KEY_PHIP_ID = `phip://${AUTHORITY}/${NAMESPACE}/${KEY_LOCAL_ID}`;
+const OBJ_PHIP_ID = `phip://${AUTHORITY}/${NAMESPACE}/${OBJ_LOCAL_ID}`;
+
+// ── crypto helpers (using fixed test keypair from vectors) ────────────
+
+const keypairs = JSON.parse(
+  fs.readFileSync(path.join(__dirname, "..", "vectors", "ed25519", "keypair.json"), "utf8")
+).keys;
+const TESTKEY = keypairs[0];
+
+const privateKey = crypto.createPrivateKey({
+  key: Buffer.from(TESTKEY.private_pkcs8_b64, "base64"),
+  format: "der",
+  type: "pkcs8",
+});
+
+function canonicalBytes(v) {
+  return Buffer.from(canonicalize(v), "utf8");
+}
+function sha256Hex(buf) {
+  return crypto.createHash("sha256").update(buf).digest("hex");
+}
+function hashEvent(event) {
+  return "sha256:" + sha256Hex(canonicalBytes(event));
+}
+function signEvent(event, keyId) {
+  const { signature, ...rest } = event;
+  const sig = crypto.sign(null, canonicalBytes(rest), privateKey);
+  return {
+    ...rest,
+    signature: {
+      algorithm: "Ed25519",
+      key_id: keyId,
+      value: sig.toString("base64url"),
+    },
+  };
+}
+function newEventId() {
+  return crypto.randomUUID();
+}
+
+// ── HTTP client ──────────────────────────────────────────────────────
+
+function request(method, relPath, body) {
+  return new Promise((resolve, reject) => {
+    const url = new URL(BASE_URL + relPath);
+    const payload = body ? Buffer.from(JSON.stringify(body), "utf8") : null;
+    const lib = url.protocol === "https:" ? https : http;
+    const opts = {
+      hostname: url.hostname,
+      port: url.port || (url.protocol === "https:" ? 443 : 80),
+      path: url.pathname + url.search,
+      method,
+      headers: payload
+        ? { "Content-Type": "application/json", "Content-Length": payload.length }
+        : {},
+    };
+    const req = lib.request(opts, (res) => {
+      let data = "";
+      res.setEncoding("utf8");
+      res.on("data", (c) => (data += c));
+      res.on("end", () => {
+        let parsed = null;
+        if (data.length) {
+          try {
+            parsed = JSON.parse(data);
+          } catch (e) {
+            return reject(new Error(`non-JSON response (${res.statusCode}): ${data.slice(0, 200)}`));
+          }
+        }
+        resolve({ status: res.statusCode, headers: res.headers, body: parsed });
+      });
+    });
+    req.on("error", reject);
+    if (payload) req.write(payload);
+    req.end();
+  });
+}
+
+// ── test harness ─────────────────────────────────────────────────────
+
+let pass = 0;
+let fail = 0;
+const failures = [];
+
+function test(name, ok, detail) {
+  if (ok) {
+    pass++;
+    console.log(`  ok  ${name}`);
+  } else {
+    fail++;
+    failures.push(`${name}${detail ? ` — ${detail}` : ""}`);
+    console.log(`  FAIL ${name}${detail ? ` — ${detail}` : ""}`);
+  }
+}
+
+function eq(a, b) {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+// ── endpoints ────────────────────────────────────────────────────────
+
+const OBJECTS = (ns) => `/.well-known/phip/objects/${ns}`;
+const RESOLVE = (ns, id) => `/.well-known/phip/resolve/${ns}/${id}`;
+const PUSH = (ns, id) => `/.well-known/phip/push/${ns}/${id}`;
+const HISTORY = (ns, id) => `/.well-known/phip/history/${ns}/${id}`;
+const QUERY = (ns) => `/.well-known/phip/query/${ns}`;
+
+// ── suite ────────────────────────────────────────────────────────────
+
+async function main() {
+  console.log(`\nPhIP conformance suite`);
+  console.log(`base:      ${BASE_URL}`);
+  console.log(`namespace: ${NAMESPACE}`);
+  console.log(`run id:    ${RUN_ID}`);
+
+  // ── 1. Bootstrap self-signed key ───────────────────────────────────
+  console.log(`\n[1] bootstrap key`);
+  const bootstrapEvent = signEvent(
+    {
+      event_id: newEventId(),
+      phip_id: KEY_PHIP_ID,
+      type: "created",
+      timestamp: new Date().toISOString(),
+      actor: KEY_PHIP_ID,
+      previous_hash: "genesis",
+      payload: {
+        object_type: "actor",
+        state: "active",
+        identity: { label: `conformance run ${RUN_ID}` },
+        attributes: {
+          "phip:keys": {
+            kty: "OKP",
+            crv: "Ed25519",
+            x: TESTKEY.public_raw_b64url,
+            not_before: "2026-01-01T00:00:00Z",
+            not_after: "2030-01-01T00:00:00Z",
+          },
+        },
+      },
+    },
+    KEY_PHIP_ID
+  );
+
+  const r1 = await request("POST", OBJECTS(NAMESPACE), bootstrapEvent);
+  test("CREATE bootstrap returns 201", r1.status === 201, `got ${r1.status}`);
+  test("CREATE bootstrap phip_id matches", r1.body && r1.body.phip_id === KEY_PHIP_ID);
+  test("CREATE bootstrap state=active", r1.body && r1.body.state === "active");
+  test(
+    "CREATE bootstrap history_head is sha256:",
+    r1.body && typeof r1.body.history_head === "string" && r1.body.history_head.startsWith("sha256:")
+  );
+  test("CREATE bootstrap history_length=1", r1.body && r1.body.history_length === 1);
+
+  // ── 2. Create component object (concept state) ────────────────────
+  console.log(`\n[2] CREATE component`);
+  const createEvent = signEvent(
+    {
+      event_id: newEventId(),
+      phip_id: OBJ_PHIP_ID,
+      type: "created",
+      timestamp: new Date().toISOString(),
+      actor: KEY_PHIP_ID,
+      previous_hash: "genesis",
+      payload: {
+        object_type: "component",
+        state: "concept",
+        identity: { serial: `CONF-${RUN_ID}` },
+      },
+    },
+    KEY_PHIP_ID
+  );
+  const r2 = await request("POST", OBJECTS(NAMESPACE), createEvent);
+  test("CREATE component returns 201", r2.status === 201, `got ${r2.status}`);
+  test("CREATE component state=concept", r2.body && r2.body.state === "concept");
+  test("CREATE component object_type=component", r2.body && r2.body.object_type === "component");
+
+  // ── 3. Idempotent GET ─────────────────────────────────────────────
+  console.log(`\n[3] GET`);
+  const r3 = await request("GET", RESOLVE(NAMESPACE, OBJ_LOCAL_ID));
+  test("GET returns 200", r3.status === 200);
+  test("GET phip_id matches", r3.body && r3.body.phip_id === OBJ_PHIP_ID);
+  test("GET history_length=1", r3.body && r3.body.history_length === 1);
+  const headAfterCreate = r3.body && r3.body.history_head;
+  test("GET history_head present", !!headAfterCreate);
+
+  // ── 4. PUSH a valid state_transition ──────────────────────────────
+  console.log(`\n[4] PUSH state_transition`);
+  const transitionEvent = signEvent(
+    {
+      event_id: newEventId(),
+      phip_id: OBJ_PHIP_ID,
+      type: "state_transition",
+      timestamp: new Date().toISOString(),
+      actor: KEY_PHIP_ID,
+      previous_hash: headAfterCreate,
+      payload: { from: "concept", to: "design" },
+    },
+    KEY_PHIP_ID
+  );
+  const r4 = await request("POST", PUSH(NAMESPACE, OBJ_LOCAL_ID), transitionEvent);
+  test("PUSH returns 201", r4.status === 201, `got ${r4.status}`);
+  test("PUSH body echoes the appended event", r4.body && r4.body.event_id === transitionEvent.event_id);
+  const afterPush = await request("GET", RESOLVE(NAMESPACE, OBJ_LOCAL_ID));
+  test("after PUSH state=design", afterPush.body && afterPush.body.state === "design");
+  test("after PUSH history_length=2", afterPush.body && afterPush.body.history_length === 2);
+
+  // ── 5. PUSH attribute_update ──────────────────────────────────────
+  console.log(`\n[5] PUSH attribute_update`);
+  const head5 = afterPush.body.history_head;
+  const attrEvent = signEvent(
+    {
+      event_id: newEventId(),
+      phip_id: OBJ_PHIP_ID,
+      type: "attribute_update",
+      timestamp: new Date().toISOString(),
+      actor: KEY_PHIP_ID,
+      previous_hash: head5,
+      payload: {
+        namespace: "phip:software",
+        updates: { firmware: `conf-fw-${RUN_ID}` },
+      },
+    },
+    KEY_PHIP_ID
+  );
+  const r5 = await request("POST", PUSH(NAMESPACE, OBJ_LOCAL_ID), attrEvent);
+  test("attribute_update returns 201", r5.status === 201, `got ${r5.status}`);
+  const afterAttr = await request("GET", RESOLVE(NAMESPACE, OBJ_LOCAL_ID));
+  test(
+    "attribute_update reflected in projection",
+    afterAttr.body &&
+      afterAttr.body.attributes &&
+      afterAttr.body.attributes["phip:software"] &&
+      afterAttr.body.attributes["phip:software"].firmware === `conf-fw-${RUN_ID}`
+  );
+
+  // ── 6. Invalid transition — design → stock ────────────────────────
+  console.log(`\n[6] invalid transition rejected`);
+  const head6 = afterAttr.body.history_head;
+  const badTransition = signEvent(
+    {
+      event_id: newEventId(),
+      phip_id: OBJ_PHIP_ID,
+      type: "state_transition",
+      timestamp: new Date().toISOString(),
+      actor: KEY_PHIP_ID,
+      previous_hash: head6,
+      payload: { from: "design", to: "stock" },
+    },
+    KEY_PHIP_ID
+  );
+  const r6 = await request("POST", PUSH(NAMESPACE, OBJ_LOCAL_ID), badTransition);
+  test("invalid transition returns 4xx", r6.status >= 400 && r6.status < 500, `got ${r6.status}`);
+  test(
+    "invalid transition error envelope",
+    r6.body && r6.body.error && r6.body.error.code === "INVALID_TRANSITION",
+    `got ${r6.body && r6.body.error && r6.body.error.code}`
+  );
+
+  // ── 7. Stale previous_hash — CHAIN_CONFLICT 409 ───────────────────
+  console.log(`\n[7] chain conflict`);
+  const staleEvent = signEvent(
+    {
+      event_id: newEventId(),
+      phip_id: OBJ_PHIP_ID,
+      type: "state_transition",
+      timestamp: new Date().toISOString(),
+      actor: KEY_PHIP_ID,
+      previous_hash: "sha256:" + "0".repeat(64),
+      payload: { from: "design", to: "qualified" },
+    },
+    KEY_PHIP_ID
+  );
+  const r7 = await request("POST", PUSH(NAMESPACE, OBJ_LOCAL_ID), staleEvent);
+  test("stale previous_hash returns 409", r7.status === 409, `got ${r7.status}`);
+  test(
+    "CHAIN_CONFLICT error code",
+    r7.body && r7.body.error && r7.body.error.code === "CHAIN_CONFLICT"
+  );
+  test(
+    "CHAIN_CONFLICT details.current_head present",
+    r7.body && r7.body.error && r7.body.error.details && typeof r7.body.error.details.current_head === "string"
+  );
+
+  // ── 8. History sub-resource ───────────────────────────────────────
+  console.log(`\n[8] history pagination`);
+  const r8 = await request("GET", HISTORY(NAMESPACE, OBJ_LOCAL_ID) + "?limit=100");
+  test("history returns 200", r8.status === 200);
+  test("history has 3 events", r8.body && r8.body.events && r8.body.events.length === 3);
+  test("history_length=3", r8.body && r8.body.history_length === 3);
+
+  // Verify chain continuity client-side.
+  const events = r8.body.events;
+  let chainOk = events[0].previous_hash === "genesis";
+  for (let i = 1; chainOk && i < events.length; i++) {
+    chainOk = events[i].previous_hash === hashEvent(events[i - 1]);
+  }
+  test("hash chain verifies end-to-end", chainOk);
+
+  // ── 9. QUERY by object_type ───────────────────────────────────────
+  console.log(`\n[9] QUERY`);
+  const r9 = await request("POST", QUERY(NAMESPACE), {
+    filters: { object_type: "component" },
+  });
+  test("QUERY returns 200", r9.status === 200);
+  test(
+    "QUERY result contains our object",
+    r9.body && Array.isArray(r9.body.matches) && r9.body.matches.includes(OBJ_PHIP_ID)
+  );
+
+  const r9b = await request("POST", QUERY(NAMESPACE), {
+    filters: { state: "design" },
+  });
+  test("QUERY by state returns 200", r9b.status === 200);
+  test(
+    "QUERY by state=design contains object",
+    r9b.body && r9b.body.matches.includes(OBJ_PHIP_ID)
+  );
+
+  // ── 10. Error envelopes ───────────────────────────────────────────
+  console.log(`\n[10] error envelopes`);
+  const r10 = await request("GET", RESOLVE(NAMESPACE, `nonexistent-${RUN_ID}`));
+  test("GET unknown object returns 404", r10.status === 404);
+  test(
+    "OBJECT_NOT_FOUND error code",
+    r10.body && r10.body.error && r10.body.error.code === "OBJECT_NOT_FOUND"
+  );
+
+  const r10b = await request("POST", OBJECTS(NAMESPACE), bootstrapEvent);
+  test("duplicate CREATE returns 409", r10b.status === 409, `got ${r10b.status}`);
+  test(
+    "OBJECT_EXISTS error code",
+    r10b.body && r10b.body.error && r10b.body.error.code === "OBJECT_EXISTS"
+  );
+
+  // ── summary ───────────────────────────────────────────────────────
+  console.log(`\n${pass} passed, ${fail} failed`);
+  if (fail > 0) {
+    console.log(`\nfailures:`);
+    for (const f of failures) console.log(`  - ${f}`);
+  }
+  process.exit(fail === 0 ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error("conformance suite crashed:", err);
+  process.exit(2);
+});

--- a/tests/package-lock.json
+++ b/tests/package-lock.json
@@ -1,0 +1,27 @@
+{
+  "name": "phip-tests",
+  "version": "0.1.0-draft",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "phip-tests",
+      "version": "0.1.0-draft",
+      "dependencies": {
+        "canonicalize": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/canonicalize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-2.1.0.tgz",
+      "integrity": "sha512-F705O3xrsUtgt98j7leetNhTWPe+5S72rlL5O4jA1pKqBVQ/dT1O1D6PFxmSXvc0SUOinWS57DKx0I3CHrXJHQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "canonicalize": "bin/canonicalize.js"
+      }
+    }
+  }
+}

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "phip-tests",
+  "version": "0.1.0-draft",
+  "private": true,
+  "description": "Language-agnostic test vectors and HTTP conformance suite for PhIP. Fixtures in vectors/ are consumed by implementations in any language to verify byte-for-byte agreement on JCS, hashing, Ed25519 signing, URI parsing, hash chains, and lifecycle transitions. The conformance suite in conformance/ black-box tests any PhIP server over HTTP.",
+  "scripts": {
+    "generate": "node vectors/generate.js",
+    "conformance": "node conformance/run.js",
+    "self-check": "node vectors/self-check.js"
+  },
+  "dependencies": {
+    "canonicalize": "^2.0.0"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/tests/vectors/README.md
+++ b/tests/vectors/README.md
@@ -1,0 +1,62 @@
+# PhIP Test Vectors
+
+Language-agnostic fixtures for implementing a PhIP client library in any
+language. Every fixture here is reproducible from two fixed Ed25519 keypairs
+and the RFC 8785 (JCS) canonicalization algorithm — if your implementation
+produces byte-identical output on these inputs, it is wire-compatible with
+the reference implementation.
+
+## Directory layout
+
+| Path                           | Covers                                          |
+| ------------------------------ | ----------------------------------------------- |
+| `ed25519/keypair.json`         | Fixed test keypairs (PKCS#8 DER and raw-32)     |
+| `jcs/cases.json`               | RFC 8785 canonical serialization                |
+| `hash/cases.json`              | SHA-256 + `sha256:` prefix (Section 10.3)       |
+| `ed25519/cases.json`           | Raw-byte and event signing (Section 11.1)       |
+| `uri/cases.json`               | URI parsing (Section 4)                         |
+| `hashchain/sequence.json`      | Hash-chain continuity (Section 10.3)            |
+| `lifecycle/manufacturing.json` | Manufacturing track transitions (Section 9.2)   |
+| `lifecycle/operational.json`   | Operational track transitions (Section 9.3)     |
+| `bootstrap/example.json`       | Self-signed bootstrap key (Section 11.2.4)      |
+
+## How to consume
+
+Each fixture is plain JSON. Load the file, iterate the `cases` (or other
+top-level array), and assert your implementation's output equals the expected
+field. For signature vectors, both *produce* and *verify* paths should be
+tested:
+
+* **Produce**: given the private key and input bytes, your `sign()` MUST
+  return `signature_b64url` (Ed25519 is deterministic per RFC 8032, so there
+  is exactly one correct signature).
+* **Verify**: given the public key, input bytes, and signature, your
+  `verify()` MUST return true.
+
+For JCS vectors, check both the string output (`canonical`) and the UTF-8
+byte encoding (`canonical_bytes_hex`) — mismatched string handling (e.g.
+UTF-16 vs UTF-8) will only show up in the byte check.
+
+## Regenerating
+
+```
+npm install
+node vectors/generate.js
+```
+
+The generator is deterministic. Regenerate whenever the spec changes any
+wire-visible behavior (canonicalization rules, hash format, signature
+scheme, lifecycle tables) and re-run `self-check.js` to confirm internal
+consistency.
+
+## Self-check
+
+```
+node vectors/self-check.js
+```
+
+This runs the same checks a client-library conformance test would run, but
+using only the committed fixtures and Node's built-in crypto + the
+`canonicalize` npm package. If this passes, the committed vectors are
+internally consistent and any client implementation producing identical
+output is byte-compatible.

--- a/tests/vectors/bootstrap/example.json
+++ b/tests/vectors/bootstrap/example.json
@@ -1,0 +1,34 @@
+{
+  "description": "Self-signed bootstrap key registration per Section 11.2.4. The object being created is an actor whose phip:keys attribute contains the public key used to sign the event itself. Verifiers MUST accept this pattern only for the `created` event on an actor whose `actor` field equals its own `phip_id`.",
+  "bootstrap_actor_id": "phip://acme.example/keys/alice-bootstrap",
+  "key_id": "test-key-alice",
+  "created_event": {
+    "event_id": "20000000-0000-4000-a000-000000000001",
+    "phip_id": "phip://acme.example/keys/alice-bootstrap",
+    "type": "created",
+    "timestamp": "2026-01-01T00:00:00Z",
+    "actor": "phip://acme.example/keys/alice-bootstrap",
+    "previous_hash": "genesis",
+    "payload": {
+      "object_type": "actor",
+      "state": "active",
+      "identity": {
+        "label": "Alice bootstrap key"
+      },
+      "attributes": {
+        "phip:keys": {
+          "kty": "OKP",
+          "crv": "Ed25519",
+          "x": "-PMJVmvQQLw38uBOg3w4CXVk6CkadzUozxMUTzq96Ws",
+          "not_before": "2026-01-01T00:00:00Z",
+          "not_after": "2030-01-01T00:00:00Z"
+        }
+      }
+    },
+    "signature": {
+      "algorithm": "Ed25519",
+      "key_id": "test-key-alice",
+      "value": "XMxYB9A5XEp-6js_aYHJHBnePVlgD1QA4QNAAzXZtAjOIrDrLdnXI3WEkTwsS1w2wOq3t8OLwg9s46aqtvsfAQ"
+    }
+  }
+}

--- a/tests/vectors/ed25519/cases.json
+++ b/tests/vectors/ed25519/cases.json
@@ -1,0 +1,123 @@
+{
+  "description": "Ed25519 signing cases per Section 11.1. `raw` cases sign arbitrary byte strings; `events` cases sign the canonical JSON of a PhIP event with the `signature` field stripped. Signatures are deterministic (RFC 8032). `signature_b64url` is the raw base64url-encoded 64-byte signature — the reference implementation stores this directly in `signature.value`.",
+  "raw": [
+    {
+      "name": "test-key-alice-empty",
+      "key_id": "test-key-alice",
+      "message_hex": "",
+      "signature_b64url": "W974TACETei0tryTPeVKs6OeuMaXtIm2UlrLYZCZZk243FvQNEsHKwMDYEwCOUdAioVfgJq7C_dffy6shNKMDQ"
+    },
+    {
+      "name": "test-key-alice-one-byte",
+      "key_id": "test-key-alice",
+      "message_hex": "61",
+      "signature_b64url": "ZJ_LPVWL2DwyfVMz9tf2guNTWDQg5NzdsUJCXi-GstNaGrB_qZyh_fuaMvBoplrXexV4l_vSk1Td9GtvXAUgBw"
+    },
+    {
+      "name": "test-key-alice-abc",
+      "key_id": "test-key-alice",
+      "message_hex": "616263",
+      "signature_b64url": "jkfxsusVfdnFcJ3U-9tUY25CCGl5k49jSaLXM935vDmqfZItrEzVn_rbMDsmXDDkK3h6zZ2kCsnnWWqWpkSOBQ"
+    },
+    {
+      "name": "test-key-alice-lorem",
+      "key_id": "test-key-alice",
+      "message_hex": "54686520717569636b2062726f776e20666f78206a756d7073206f76657220746865206c617a7920646f67",
+      "signature_b64url": "LLS_hbDMrh-VrRerDXo_1hRozRYGcBT7wvDTdVd8NSUbkm4_H3Lh0_8z0zsPu_fM4J31Yys3xuTukdl7WZ5eCA"
+    },
+    {
+      "name": "test-key-bob-empty",
+      "key_id": "test-key-bob",
+      "message_hex": "",
+      "signature_b64url": "xIBX_6oDtJOtD0YfTjCtQC8DHDwwk5h_UkXHEdWK6h9iQkSml-xQWGoiL150wAQ9wD-DGRmY4YNhlCZzBNGVDg"
+    },
+    {
+      "name": "test-key-bob-one-byte",
+      "key_id": "test-key-bob",
+      "message_hex": "61",
+      "signature_b64url": "Uym0M2AbUzuKTeKaioz3Se8j8KorPyx6x4x3dxQGPNp1_ZM_8tawlNnLoGWc7GllNhi3HN2fHJG0zMS1wUEbCA"
+    },
+    {
+      "name": "test-key-bob-abc",
+      "key_id": "test-key-bob",
+      "message_hex": "616263",
+      "signature_b64url": "bExcYg3QvCa2HtDZxcYvf5IURSDPOAKBK92HYx65XGYUKdbOQYCt8Mv7LLu_8kMhPCAUzdxwv1PLdBPy0b-LCQ"
+    },
+    {
+      "name": "test-key-bob-lorem",
+      "key_id": "test-key-bob",
+      "message_hex": "54686520717569636b2062726f776e20666f78206a756d7073206f76657220746865206c617a7920646f67",
+      "signature_b64url": "Zom11L03KX5hmWRE-RYO-wNYgbWfk7JxJWpl7Gzea3yo3UxFLKdhfCXRxn9LEgzeHBGZPdiKvhewtwztv2TfCA"
+    }
+  ],
+  "events": [
+    {
+      "name": "note-event",
+      "key_id": "test-key-alice",
+      "event_unsigned": {
+        "event_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+        "phip_id": "phip://acme.example/parts/widget-001",
+        "type": "note",
+        "timestamp": "2026-01-01T00:00:00Z",
+        "actor": "phip://acme.example/actors/alice",
+        "previous_hash": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "payload": {
+          "text": "hello world"
+        }
+      },
+      "canonical_bytes_hex": "7b226163746f72223a22706869703a2f2f61636d652e6578616d706c652f6163746f72732f616c696365222c226576656e745f6964223a2261316232633364342d653566362d373839302d616263642d656631323334353637383930222c227061796c6f6164223a7b2274657874223a2268656c6c6f20776f726c64227d2c22706869705f6964223a22706869703a2f2f61636d652e6578616d706c652f70617274732f7769646765742d303031222c2270726576696f75735f68617368223a227368613235363a65336230633434323938666331633134396166626634633839393666623932343237616534316534363439623933346361343935393931623738353262383535222c2274696d657374616d70223a22323032362d30312d30315430303a30303a30305a222c2274797065223a226e6f7465227d",
+      "signature_b64url": "vpkC3WU03Oc2o1DjGusZm41EopZNeYlWTwiBHGEnK4neEchGbUnnLJltJjEnIy_yyzArxqQ0N8Ype__QTE1MCA",
+      "signed_event": {
+        "event_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+        "phip_id": "phip://acme.example/parts/widget-001",
+        "type": "note",
+        "timestamp": "2026-01-01T00:00:00Z",
+        "actor": "phip://acme.example/actors/alice",
+        "previous_hash": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "payload": {
+          "text": "hello world"
+        },
+        "signature": {
+          "algorithm": "Ed25519",
+          "key_id": "test-key-alice",
+          "value": "vpkC3WU03Oc2o1DjGusZm41EopZNeYlWTwiBHGEnK4neEchGbUnnLJltJjEnIy_yyzArxqQ0N8Ype__QTE1MCA"
+        }
+      }
+    },
+    {
+      "name": "state-transition",
+      "key_id": "test-key-bob",
+      "event_unsigned": {
+        "event_id": "b2c3d4e5-f6a7-8901-bcde-f23456789012",
+        "phip_id": "phip://acme.example/parts/widget-001",
+        "type": "state_transition",
+        "timestamp": "2026-01-02T12:00:00Z",
+        "actor": "phip://acme.example/actors/bob",
+        "previous_hash": "sha256:deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+        "payload": {
+          "from": "stock",
+          "to": "deployed"
+        }
+      },
+      "canonical_bytes_hex": "7b226163746f72223a22706869703a2f2f61636d652e6578616d706c652f6163746f72732f626f62222c226576656e745f6964223a2262326333643465352d663661372d383930312d626364652d663233343536373839303132222c227061796c6f6164223a7b2266726f6d223a2273746f636b222c22746f223a226465706c6f796564227d2c22706869705f6964223a22706869703a2f2f61636d652e6578616d706c652f70617274732f7769646765742d303031222c2270726576696f75735f68617368223a227368613235363a64656164626565666465616462656566646561646265656664656164626565666465616462656566646561646265656664656164626565666465616462656566222c2274696d657374616d70223a22323032362d30312d30325431323a30303a30305a222c2274797065223a2273746174655f7472616e736974696f6e227d",
+      "signature_b64url": "UyWm-8bQdsneVuViQSWOeR8XG4Cx5zA0UQt8_8X2er7_MCNXgp7Lrjm6M_R0HtJbXicm8G-dxoLrQpWk8lVFCw",
+      "signed_event": {
+        "event_id": "b2c3d4e5-f6a7-8901-bcde-f23456789012",
+        "phip_id": "phip://acme.example/parts/widget-001",
+        "type": "state_transition",
+        "timestamp": "2026-01-02T12:00:00Z",
+        "actor": "phip://acme.example/actors/bob",
+        "previous_hash": "sha256:deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+        "payload": {
+          "from": "stock",
+          "to": "deployed"
+        },
+        "signature": {
+          "algorithm": "Ed25519",
+          "key_id": "test-key-bob",
+          "value": "UyWm-8bQdsneVuViQSWOeR8XG4Cx5zA0UQt8_8X2er7_MCNXgp7Lrjm6M_R0HtJbXicm8G-dxoLrQpWk8lVFCw"
+        }
+      }
+    }
+  ]
+}

--- a/tests/vectors/ed25519/keypair.json
+++ b/tests/vectors/ed25519/keypair.json
@@ -1,0 +1,15 @@
+{
+  "description": "Fixed Ed25519 test keypairs in PKCS#8 DER (base64) and raw-32-byte (base64url) form. Implementations SHOULD load the private key from PKCS#8 DER and derive the public key from the raw 32 bytes.",
+  "keys": [
+    {
+      "id": "test-key-alice",
+      "private_pkcs8_b64": "MC4CAQAwBQYDK2VwBCIEILYVuTR2efrX2+iRiMd6EmrgZNMaFhxPi8HpoS/N7PUh",
+      "public_raw_b64url": "-PMJVmvQQLw38uBOg3w4CXVk6CkadzUozxMUTzq96Ws"
+    },
+    {
+      "id": "test-key-bob",
+      "private_pkcs8_b64": "MC4CAQAwBQYDK2VwBCIEICzx/gACRv1KqpfCPNBGxWTqJ/Opc+SqwDEk5L+qEdCY",
+      "public_raw_b64url": "lO6Idw5fAiglC574c3jennZmmUNhgaUoUzhx6K-D6MQ"
+    }
+  ]
+}

--- a/tests/vectors/generate.js
+++ b/tests/vectors/generate.js
@@ -1,0 +1,551 @@
+// Test vector generator.
+//
+// Produces language-agnostic fixtures in tests/vectors/*/ from two fixed
+// Ed25519 keypairs and a curated set of canonicalization inputs. The fixtures
+// are committed to the repo and consumed by phip-js, phip-py, and any other
+// client library to verify byte-for-byte agreement on JCS, SHA-256,
+// Ed25519 sign/verify, URI parsing, hash-chain continuity, and lifecycle
+// transitions.
+//
+// Event field names follow Section 10.1 exactly: event_id, phip_id, type,
+// timestamp, actor, previous_hash, payload, signature. The first event in
+// a history uses previous_hash = "genesis" per Section 10.3.
+//
+// Run `node vectors/generate.js` from the tests/ directory. Output is
+// deterministic — the same Node version produces the same bytes every run.
+
+"use strict";
+
+const crypto = require("node:crypto");
+const fs = require("node:fs");
+const path = require("node:path");
+const canonicalize = require("canonicalize");
+
+const OUT = __dirname;
+
+// Two fixed keypairs (PKCS#8 DER, base64). Used across all signing vectors.
+// These are disposable test keys — do not use for anything real.
+const KEYPAIRS = [
+  {
+    id: "test-key-alice",
+    private_pkcs8_b64:
+      "MC4CAQAwBQYDK2VwBCIEILYVuTR2efrX2+iRiMd6EmrgZNMaFhxPi8HpoS/N7PUh",
+    public_raw_b64url: "-PMJVmvQQLw38uBOg3w4CXVk6CkadzUozxMUTzq96Ws",
+  },
+  {
+    id: "test-key-bob",
+    private_pkcs8_b64:
+      "MC4CAQAwBQYDK2VwBCIEICzx/gACRv1KqpfCPNBGxWTqJ/Opc+SqwDEk5L+qEdCY",
+    public_raw_b64url: "lO6Idw5fAiglC574c3jennZmmUNhgaUoUzhx6K-D6MQ",
+  },
+];
+
+const keyObjects = KEYPAIRS.map((k) => {
+  const privateKey = crypto.createPrivateKey({
+    key: Buffer.from(k.private_pkcs8_b64, "base64"),
+    format: "der",
+    type: "pkcs8",
+  });
+  const raw = Buffer.from(k.public_raw_b64url, "base64url");
+  const spki = Buffer.concat([
+    Buffer.from("302a300506032b6570032100", "hex"),
+    raw,
+  ]);
+  const publicKey = crypto.createPublicKey({
+    key: spki,
+    format: "der",
+    type: "spki",
+  });
+  return { ...k, privateKey, publicKey };
+});
+
+function getKey(id) {
+  const k = keyObjects.find((x) => x.id === id);
+  if (!k) throw new Error(`unknown test key: ${id}`);
+  return k;
+}
+
+function canonicalBytes(value) {
+  return Buffer.from(canonicalize(value), "utf8");
+}
+
+function sha256Hex(buf) {
+  return crypto.createHash("sha256").update(buf).digest("hex");
+}
+
+function hashEvent(event) {
+  return "sha256:" + sha256Hex(canonicalBytes(event));
+}
+
+function signEvent(event, keyId) {
+  const key = getKey(keyId);
+  const { signature, ...rest } = event;
+  const sig = crypto.sign(null, canonicalBytes(rest), key.privateKey);
+  return {
+    ...rest,
+    signature: {
+      algorithm: "Ed25519",
+      key_id: keyId,
+      value: sig.toString("base64url"),
+    },
+  };
+}
+
+function writeJson(relPath, obj) {
+  const full = path.join(OUT, relPath);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, JSON.stringify(obj, null, 2) + "\n");
+  console.log(`wrote ${relPath}`);
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// 1. Keypair fixture
+// ─────────────────────────────────────────────────────────────────────
+
+writeJson("ed25519/keypair.json", {
+  description:
+    "Fixed Ed25519 test keypairs in PKCS#8 DER (base64) and raw-32-byte " +
+    "(base64url) form. Implementations SHOULD load the private key from " +
+    "PKCS#8 DER and derive the public key from the raw 32 bytes.",
+  keys: KEYPAIRS,
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// 2. JCS cases — RFC 8785 canonical serialization
+// ─────────────────────────────────────────────────────────────────────
+
+const JCS_INPUTS = [
+  {
+    name: "empty-object",
+    description: "Empty JSON object.",
+    input: {},
+  },
+  {
+    name: "empty-array",
+    description: "Empty JSON array.",
+    input: [],
+  },
+  {
+    name: "key-ordering",
+    description:
+      "Keys MUST be emitted in sorted code-point order, regardless of input order.",
+    input: { c: 3, a: 1, b: 2 },
+  },
+  {
+    name: "nested-ordering",
+    description: "Sorting applies recursively to nested objects.",
+    input: { outer: { z: 1, a: 2 }, alpha: { c: 3, b: 4 } },
+  },
+  {
+    name: "unicode-values",
+    description:
+      "Non-ASCII strings are encoded as UTF-8. Code points below 0x20 are " +
+      "escaped; printable code points are emitted literally.",
+    input: { greeting: "héllo", emoji: "🧠", cjk: "日本語" },
+  },
+  {
+    name: "unicode-keys",
+    description: "Keys are sorted by UTF-16 code unit, like ECMAScript.",
+    input: { "é": 1, "a": 2, "z": 3 },
+  },
+  {
+    name: "escapes",
+    description: "Mandatory JSON string escapes.",
+    input: { s: 'line1\nline2\t"quoted"\\backslash' },
+  },
+  {
+    name: "numbers-integers",
+    description: "Integers are emitted without fractional part.",
+    input: { zero: 0, pos: 42, neg: -17, big: 2147483647 },
+  },
+  {
+    name: "numbers-floats",
+    description:
+      "Floating-point uses ECMAScript Number.prototype.toString — shortest " +
+      "round-trip form.",
+    input: { half: 0.5, pi: 3.14159, sci: 1e21 },
+  },
+  {
+    name: "booleans-and-null",
+    description: "true/false/null literals.",
+    input: { t: true, f: false, n: null },
+  },
+  {
+    name: "mixed-array",
+    description: "Array order MUST be preserved (unlike object keys).",
+    input: [3, 1, 2, { b: 2, a: 1 }],
+  },
+  {
+    name: "deep-nesting",
+    description: "Multiple levels of nesting still produce stable output.",
+    input: { a: { b: { c: { d: { e: "leaf" } } } } },
+  },
+];
+
+const jcsCases = JCS_INPUTS.map((c) => {
+  const canonical = canonicalize(c.input);
+  const bytes = Buffer.from(canonical, "utf8");
+  return {
+    name: c.name,
+    description: c.description,
+    input: c.input,
+    canonical,
+    canonical_bytes_hex: bytes.toString("hex"),
+    canonical_byte_length: bytes.length,
+  };
+});
+
+writeJson("jcs/cases.json", {
+  description:
+    "RFC 8785 JCS canonicalization cases. For each case, `canonical` is the " +
+    "expected string output and `canonical_bytes_hex` is its UTF-8 encoding " +
+    "in hex. Implementations MUST produce byte-identical output.",
+  cases: jcsCases,
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// 3. Hash cases — SHA-256 with "sha256:" prefix, per Section 10.3
+// ─────────────────────────────────────────────────────────────────────
+
+const HASH_INPUTS = [
+  { name: "empty-object", input: {} },
+  { name: "single-key", input: { a: 1 } },
+  {
+    name: "example-event",
+    input: {
+      event_id: "c2b8d7e4-8f4a-4e3c-9a5f-10e4d8f9a1b2",
+      phip_id: "phip://acme.example/parts/widget-001",
+      type: "note",
+      timestamp: "2026-01-01T00:00:00Z",
+      actor: "phip://acme.example/actors/alice",
+      previous_hash:
+        "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      payload: { text: "hello" },
+    },
+  },
+];
+
+const hashCases = HASH_INPUTS.map((c) => {
+  const canonical = canonicalize(c.input);
+  const hex = sha256Hex(Buffer.from(canonical, "utf8"));
+  return {
+    name: c.name,
+    input: c.input,
+    canonical,
+    hash: "sha256:" + hex,
+  };
+});
+
+writeJson("hash/cases.json", {
+  description:
+    "Event hash cases per Section 10.3. `hash` is the SHA-256 of the UTF-8 " +
+    "bytes of the JCS canonicalization of `input`, prefixed with 'sha256:' " +
+    "and encoded as 64 lowercase hex characters.",
+  cases: hashCases,
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// 4. Ed25519 cases — raw bytes + event signing
+// ─────────────────────────────────────────────────────────────────────
+
+const RAW_MESSAGES = [
+  { name: "empty", message_hex: "" },
+  { name: "one-byte", message_hex: "61" },
+  {
+    name: "abc",
+    message_hex: Buffer.from("abc", "utf8").toString("hex"),
+  },
+  {
+    name: "lorem",
+    message_hex: Buffer.from(
+      "The quick brown fox jumps over the lazy dog",
+      "utf8"
+    ).toString("hex"),
+  },
+];
+
+const rawCases = [];
+for (const keyId of ["test-key-alice", "test-key-bob"]) {
+  const key = getKey(keyId);
+  for (const m of RAW_MESSAGES) {
+    const sig = crypto.sign(
+      null,
+      Buffer.from(m.message_hex, "hex"),
+      key.privateKey
+    );
+    rawCases.push({
+      name: `${keyId}-${m.name}`,
+      key_id: keyId,
+      message_hex: m.message_hex,
+      signature_b64url: sig.toString("base64url"),
+    });
+  }
+}
+
+// Event-signing cases — canonicalize the event minus its signature, then sign.
+const EVENT_INPUTS = [
+  {
+    name: "note-event",
+    key_id: "test-key-alice",
+    event: {
+      event_id: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+      phip_id: "phip://acme.example/parts/widget-001",
+      type: "note",
+      timestamp: "2026-01-01T00:00:00Z",
+      actor: "phip://acme.example/actors/alice",
+      previous_hash:
+        "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      payload: { text: "hello world" },
+    },
+  },
+  {
+    name: "state-transition",
+    key_id: "test-key-bob",
+    event: {
+      event_id: "b2c3d4e5-f6a7-8901-bcde-f23456789012",
+      phip_id: "phip://acme.example/parts/widget-001",
+      type: "state_transition",
+      timestamp: "2026-01-02T12:00:00Z",
+      actor: "phip://acme.example/actors/bob",
+      previous_hash:
+        "sha256:deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+      payload: { from: "stock", to: "deployed" },
+    },
+  },
+];
+
+const eventCases = EVENT_INPUTS.map((c) => {
+  const canonical = canonicalize(c.event);
+  const bytes = Buffer.from(canonical, "utf8");
+  const signed = signEvent(c.event, c.key_id);
+  return {
+    name: c.name,
+    key_id: c.key_id,
+    event_unsigned: c.event,
+    canonical_bytes_hex: bytes.toString("hex"),
+    signature_b64url: signed.signature.value,
+    signed_event: signed,
+  };
+});
+
+writeJson("ed25519/cases.json", {
+  description:
+    "Ed25519 signing cases per Section 11.1. `raw` cases sign arbitrary byte " +
+    "strings; `events` cases sign the canonical JSON of a PhIP event with " +
+    "the `signature` field stripped. Signatures are deterministic (RFC 8032). " +
+    "`signature_b64url` is the raw base64url-encoded 64-byte signature — the " +
+    "reference implementation stores this directly in `signature.value`.",
+  raw: rawCases,
+  events: eventCases,
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// 5. URI parsing cases — Section 4
+// ─────────────────────────────────────────────────────────────────────
+
+writeJson("uri/cases.json", {
+  description:
+    "PhIP URI parsing per Section 4. Valid URIs decompose into authority, " +
+    "namespace, local_id, and optional sub_path (array of path segments " +
+    "after local_id, if any). Invalid URIs MUST be rejected.",
+  valid: [
+    {
+      uri: "phip://acme.example/parts/widget-001",
+      authority: "acme.example",
+      namespace: "parts",
+      local_id: "widget-001",
+      sub_path: [],
+    },
+    {
+      uri: "phip://acme.example/parts/widget-001/sensors/temp-1",
+      authority: "acme.example",
+      namespace: "parts",
+      local_id: "widget-001",
+      sub_path: ["sensors", "temp-1"],
+    },
+    {
+      uri: "phip://sub.acme.example/lots/LOT-2026-04-001",
+      authority: "sub.acme.example",
+      namespace: "lots",
+      local_id: "LOT-2026-04-001",
+      sub_path: [],
+    },
+    {
+      uri: "phip://acme-mfg.co.uk/racks/R1.A.07",
+      authority: "acme-mfg.co.uk",
+      namespace: "racks",
+      local_id: "R1.A.07",
+      sub_path: [],
+    },
+  ],
+  invalid: [
+    { uri: "http://acme.example/parts/x", reason: "wrong scheme" },
+    { uri: "phip:/acme.example/parts/x", reason: "missing //" },
+    { uri: "phip://acme.example/parts", reason: "missing local-id segment" },
+    { uri: "phip://acme.example//widget", reason: "empty namespace segment" },
+    { uri: "phip:///parts/widget", reason: "empty authority" },
+    { uri: "phip://acme example/parts/x", reason: "space in authority" },
+  ],
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// 6. Hash chain sequence — Section 10.3
+// ─────────────────────────────────────────────────────────────────────
+
+const PHIP_ID = "phip://acme.example/parts/widget-001";
+const chainEvents = [];
+
+let event0 = {
+  event_id: "10000000-0000-4000-a000-000000000001",
+  phip_id: PHIP_ID,
+  type: "created",
+  timestamp: "2026-01-01T00:00:00Z",
+  actor: "phip://acme.example/actors/alice",
+  previous_hash: "genesis",
+  payload: { object_type: "component", state: "concept" },
+};
+event0 = signEvent(event0, "test-key-alice");
+chainEvents.push(event0);
+
+let event1 = {
+  event_id: "10000000-0000-4000-a000-000000000002",
+  phip_id: PHIP_ID,
+  type: "state_transition",
+  timestamp: "2026-01-02T00:00:00Z",
+  actor: "phip://acme.example/actors/alice",
+  previous_hash: hashEvent(event0),
+  payload: { from: "concept", to: "design" },
+};
+event1 = signEvent(event1, "test-key-alice");
+chainEvents.push(event1);
+
+let event2 = {
+  event_id: "10000000-0000-4000-a000-000000000003",
+  phip_id: PHIP_ID,
+  type: "note",
+  timestamp: "2026-01-03T00:00:00Z",
+  actor: "phip://acme.example/actors/bob",
+  previous_hash: hashEvent(event1),
+  payload: { text: "Design review complete" },
+};
+event2 = signEvent(event2, "test-key-bob");
+chainEvents.push(event2);
+
+writeJson("hashchain/sequence.json", {
+  description:
+    "A three-event hash chain. Implementations MUST verify that each " +
+    "event's `previous_hash` equals the SHA-256-prefixed hash of the " +
+    "full canonical-JSON serialization of the preceding event " +
+    "(signature field included), per Section 10.3. The first event's " +
+    "previous_hash is the literal string \"genesis\".",
+  phip_id: PHIP_ID,
+  events: chainEvents,
+  expected_hashes: chainEvents.map((e) => hashEvent(e)),
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// 7. Lifecycle transition cases — Section 9
+// ─────────────────────────────────────────────────────────────────────
+
+const MANUFACTURING_TRANSITIONS = {
+  concept: ["design"],
+  design: ["prototype", "qualified"],
+  prototype: ["design", "qualified"],
+  qualified: ["stock", "consumed"],
+  stock: ["deployed", "decommissioned", "consumed"],
+  deployed: ["maintained", "decommissioned"],
+  maintained: ["deployed", "decommissioned"],
+  decommissioned: ["consumed", "disposed"],
+  consumed: [],
+  disposed: [],
+};
+
+const OPERATIONAL_TRANSITIONS = {
+  planned: ["active", "archived"],
+  active: ["inactive", "archived"],
+  inactive: ["active", "archived"],
+  archived: [],
+};
+
+function expandTransitions(table) {
+  const valid = [];
+  const invalid = [];
+  const states = Object.keys(table);
+  for (const from of states) {
+    for (const to of states) {
+      if (table[from].includes(to)) {
+        valid.push({ from, to });
+      } else if (from !== to) {
+        invalid.push({ from, to });
+      }
+    }
+  }
+  return { valid, invalid };
+}
+
+writeJson("lifecycle/manufacturing.json", {
+  description:
+    "Manufacturing track state transitions per Section 9.2.1. Applies to " +
+    "object types: material, component, assembly, system, lot.",
+  object_types: ["material", "component", "assembly", "system", "lot"],
+  states: Object.keys(MANUFACTURING_TRANSITIONS),
+  terminal_states: ["consumed", "disposed"],
+  transitions: MANUFACTURING_TRANSITIONS,
+  ...expandTransitions(MANUFACTURING_TRANSITIONS),
+});
+
+writeJson("lifecycle/operational.json", {
+  description:
+    "Operational track state transitions per Section 9.3.1. Applies to " +
+    "object types: actor, location, vehicle. Archived objects MAY accept " +
+    "`note` events; all other terminal states reject every event.",
+  object_types: ["actor", "location", "vehicle"],
+  states: Object.keys(OPERATIONAL_TRANSITIONS),
+  terminal_states: ["archived"],
+  archived_accepts_note: true,
+  transitions: OPERATIONAL_TRANSITIONS,
+  ...expandTransitions(OPERATIONAL_TRANSITIONS),
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// 8. Bootstrap key self-signing — Section 11.2.4
+// ─────────────────────────────────────────────────────────────────────
+
+const BOOTSTRAP_PHIP_ID = "phip://acme.example/keys/alice-bootstrap";
+let bootstrapCreated = {
+  event_id: "20000000-0000-4000-a000-000000000001",
+  phip_id: BOOTSTRAP_PHIP_ID,
+  type: "created",
+  timestamp: "2026-01-01T00:00:00Z",
+  actor: BOOTSTRAP_PHIP_ID,
+  previous_hash: "genesis",
+  payload: {
+    object_type: "actor",
+    state: "active",
+    identity: { label: "Alice bootstrap key" },
+    attributes: {
+      "phip:keys": {
+        kty: "OKP",
+        crv: "Ed25519",
+        x: getKey("test-key-alice").public_raw_b64url,
+        not_before: "2026-01-01T00:00:00Z",
+        not_after: "2030-01-01T00:00:00Z",
+      },
+    },
+  },
+};
+bootstrapCreated = signEvent(bootstrapCreated, "test-key-alice");
+
+writeJson("bootstrap/example.json", {
+  description:
+    "Self-signed bootstrap key registration per Section 11.2.4. The object " +
+    "being created is an actor whose phip:keys attribute contains the " +
+    "public key used to sign the event itself. Verifiers MUST accept this " +
+    "pattern only for the `created` event on an actor whose `actor` field " +
+    "equals its own `phip_id`.",
+  bootstrap_actor_id: BOOTSTRAP_PHIP_ID,
+  key_id: "test-key-alice",
+  created_event: bootstrapCreated,
+});
+
+console.log("\nall vectors written.");

--- a/tests/vectors/generate.js
+++ b/tests/vectors/generate.js
@@ -486,8 +486,8 @@ function expandTransitions(table) {
 writeJson("lifecycle/manufacturing.json", {
   description:
     "Manufacturing track state transitions per Section 9.2.1. Applies to " +
-    "object types: material, component, assembly, system, lot.",
-  object_types: ["material", "component", "assembly", "system", "lot"],
+    "object types: material, component, assembly, system, lot, design.",
+  object_types: ["material", "component", "assembly", "system", "lot", "design"],
   states: Object.keys(MANUFACTURING_TRANSITIONS),
   terminal_states: ["consumed", "disposed"],
   transitions: MANUFACTURING_TRANSITIONS,

--- a/tests/vectors/hash/cases.json
+++ b/tests/vectors/hash/cases.json
@@ -1,0 +1,35 @@
+{
+  "description": "Event hash cases per Section 10.3. `hash` is the SHA-256 of the UTF-8 bytes of the JCS canonicalization of `input`, prefixed with 'sha256:' and encoded as 64 lowercase hex characters.",
+  "cases": [
+    {
+      "name": "empty-object",
+      "input": {},
+      "canonical": "{}",
+      "hash": "sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a"
+    },
+    {
+      "name": "single-key",
+      "input": {
+        "a": 1
+      },
+      "canonical": "{\"a\":1}",
+      "hash": "sha256:015abd7f5cc57a2dd94b7590f04ad8084273905ee33ec5cebeae62276a97f862"
+    },
+    {
+      "name": "example-event",
+      "input": {
+        "event_id": "c2b8d7e4-8f4a-4e3c-9a5f-10e4d8f9a1b2",
+        "phip_id": "phip://acme.example/parts/widget-001",
+        "type": "note",
+        "timestamp": "2026-01-01T00:00:00Z",
+        "actor": "phip://acme.example/actors/alice",
+        "previous_hash": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "payload": {
+          "text": "hello"
+        }
+      },
+      "canonical": "{\"actor\":\"phip://acme.example/actors/alice\",\"event_id\":\"c2b8d7e4-8f4a-4e3c-9a5f-10e4d8f9a1b2\",\"payload\":{\"text\":\"hello\"},\"phip_id\":\"phip://acme.example/parts/widget-001\",\"previous_hash\":\"sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\",\"timestamp\":\"2026-01-01T00:00:00Z\",\"type\":\"note\"}",
+      "hash": "sha256:8d746f5f333643627aca8dcca31f9ce1dd83dbec610921794631367d0c16a227"
+    }
+  ]
+}

--- a/tests/vectors/hashchain/sequence.json
+++ b/tests/vectors/hashchain/sequence.json
@@ -1,0 +1,61 @@
+{
+  "description": "A three-event hash chain. Implementations MUST verify that each event's `previous_hash` equals the SHA-256-prefixed hash of the full canonical-JSON serialization of the preceding event (signature field included), per Section 10.3. The first event's previous_hash is the literal string \"genesis\".",
+  "phip_id": "phip://acme.example/parts/widget-001",
+  "events": [
+    {
+      "event_id": "10000000-0000-4000-a000-000000000001",
+      "phip_id": "phip://acme.example/parts/widget-001",
+      "type": "created",
+      "timestamp": "2026-01-01T00:00:00Z",
+      "actor": "phip://acme.example/actors/alice",
+      "previous_hash": "genesis",
+      "payload": {
+        "object_type": "component",
+        "state": "concept"
+      },
+      "signature": {
+        "algorithm": "Ed25519",
+        "key_id": "test-key-alice",
+        "value": "ZF-vki7r3b14FV_hlC11btq0Czd9B3UcNteGwX-iq975qQ3alommNDQfaM-5l5Y-JLRiqd0ve6BdZlf60iIECQ"
+      }
+    },
+    {
+      "event_id": "10000000-0000-4000-a000-000000000002",
+      "phip_id": "phip://acme.example/parts/widget-001",
+      "type": "state_transition",
+      "timestamp": "2026-01-02T00:00:00Z",
+      "actor": "phip://acme.example/actors/alice",
+      "previous_hash": "sha256:740ade2a24534da3201a8bd246da54c525556a338c94442098673dfad63f6270",
+      "payload": {
+        "from": "concept",
+        "to": "design"
+      },
+      "signature": {
+        "algorithm": "Ed25519",
+        "key_id": "test-key-alice",
+        "value": "AH70h_68c4z2VYll09bivsVGd1K5YSQT7kMDYqenv7YnGCr0iop6d6AxqziDiPfTGnt_TokNgCGC2X2PF36qAw"
+      }
+    },
+    {
+      "event_id": "10000000-0000-4000-a000-000000000003",
+      "phip_id": "phip://acme.example/parts/widget-001",
+      "type": "note",
+      "timestamp": "2026-01-03T00:00:00Z",
+      "actor": "phip://acme.example/actors/bob",
+      "previous_hash": "sha256:edfa1024542fc2072c2507012ae4c0be535d907106bf8fcd3a04f54e76c6b5c3",
+      "payload": {
+        "text": "Design review complete"
+      },
+      "signature": {
+        "algorithm": "Ed25519",
+        "key_id": "test-key-bob",
+        "value": "OEuY5Od8Aks7ooYUxiAxOGceeOowFQr9bQUrrjTgw3MYu_RlJ2qjeboHHeTAHjpB4yHThEKEqJZM5pz7k5v0Ag"
+      }
+    }
+  ],
+  "expected_hashes": [
+    "sha256:740ade2a24534da3201a8bd246da54c525556a338c94442098673dfad63f6270",
+    "sha256:edfa1024542fc2072c2507012ae4c0be535d907106bf8fcd3a04f54e76c6b5c3",
+    "sha256:90741b003a5d337918a67793343c4cabd64ffefa59d765558f74e8dd619a88e9"
+  ]
+}

--- a/tests/vectors/jcs/cases.json
+++ b/tests/vectors/jcs/cases.json
@@ -1,0 +1,155 @@
+{
+  "description": "RFC 8785 JCS canonicalization cases. For each case, `canonical` is the expected string output and `canonical_bytes_hex` is its UTF-8 encoding in hex. Implementations MUST produce byte-identical output.",
+  "cases": [
+    {
+      "name": "empty-object",
+      "description": "Empty JSON object.",
+      "input": {},
+      "canonical": "{}",
+      "canonical_bytes_hex": "7b7d",
+      "canonical_byte_length": 2
+    },
+    {
+      "name": "empty-array",
+      "description": "Empty JSON array.",
+      "input": [],
+      "canonical": "[]",
+      "canonical_bytes_hex": "5b5d",
+      "canonical_byte_length": 2
+    },
+    {
+      "name": "key-ordering",
+      "description": "Keys MUST be emitted in sorted code-point order, regardless of input order.",
+      "input": {
+        "c": 3,
+        "a": 1,
+        "b": 2
+      },
+      "canonical": "{\"a\":1,\"b\":2,\"c\":3}",
+      "canonical_bytes_hex": "7b2261223a312c2262223a322c2263223a337d",
+      "canonical_byte_length": 19
+    },
+    {
+      "name": "nested-ordering",
+      "description": "Sorting applies recursively to nested objects.",
+      "input": {
+        "outer": {
+          "z": 1,
+          "a": 2
+        },
+        "alpha": {
+          "c": 3,
+          "b": 4
+        }
+      },
+      "canonical": "{\"alpha\":{\"b\":4,\"c\":3},\"outer\":{\"a\":2,\"z\":1}}",
+      "canonical_bytes_hex": "7b22616c706861223a7b2262223a342c2263223a337d2c226f75746572223a7b2261223a322c227a223a317d7d",
+      "canonical_byte_length": 45
+    },
+    {
+      "name": "unicode-values",
+      "description": "Non-ASCII strings are encoded as UTF-8. Code points below 0x20 are escaped; printable code points are emitted literally.",
+      "input": {
+        "greeting": "héllo",
+        "emoji": "🧠",
+        "cjk": "日本語"
+      },
+      "canonical": "{\"cjk\":\"日本語\",\"emoji\":\"🧠\",\"greeting\":\"héllo\"}",
+      "canonical_bytes_hex": "7b22636a6b223a22e697a5e69cace8aa9e222c22656d6f6a69223a22f09fa7a0222c226772656574696e67223a2268c3a96c6c6f227d",
+      "canonical_byte_length": 54
+    },
+    {
+      "name": "unicode-keys",
+      "description": "Keys are sorted by UTF-16 code unit, like ECMAScript.",
+      "input": {
+        "é": 1,
+        "a": 2,
+        "z": 3
+      },
+      "canonical": "{\"a\":2,\"z\":3,\"é\":1}",
+      "canonical_bytes_hex": "7b2261223a322c227a223a332c22c3a9223a317d",
+      "canonical_byte_length": 20
+    },
+    {
+      "name": "escapes",
+      "description": "Mandatory JSON string escapes.",
+      "input": {
+        "s": "line1\nline2\t\"quoted\"\\backslash"
+      },
+      "canonical": "{\"s\":\"line1\\nline2\\t\\\"quoted\\\"\\\\backslash\"}",
+      "canonical_bytes_hex": "7b2273223a226c696e65315c6e6c696e65325c745c2271756f7465645c225c5c6261636b736c617368227d",
+      "canonical_byte_length": 43
+    },
+    {
+      "name": "numbers-integers",
+      "description": "Integers are emitted without fractional part.",
+      "input": {
+        "zero": 0,
+        "pos": 42,
+        "neg": -17,
+        "big": 2147483647
+      },
+      "canonical": "{\"big\":2147483647,\"neg\":-17,\"pos\":42,\"zero\":0}",
+      "canonical_bytes_hex": "7b22626967223a323134373438333634372c226e6567223a2d31372c22706f73223a34322c227a65726f223a307d",
+      "canonical_byte_length": 46
+    },
+    {
+      "name": "numbers-floats",
+      "description": "Floating-point uses ECMAScript Number.prototype.toString — shortest round-trip form.",
+      "input": {
+        "half": 0.5,
+        "pi": 3.14159,
+        "sci": 1e+21
+      },
+      "canonical": "{\"half\":0.5,\"pi\":3.14159,\"sci\":1e+21}",
+      "canonical_bytes_hex": "7b2268616c66223a302e352c227069223a332e31343135392c22736369223a31652b32317d",
+      "canonical_byte_length": 37
+    },
+    {
+      "name": "booleans-and-null",
+      "description": "true/false/null literals.",
+      "input": {
+        "t": true,
+        "f": false,
+        "n": null
+      },
+      "canonical": "{\"f\":false,\"n\":null,\"t\":true}",
+      "canonical_bytes_hex": "7b2266223a66616c73652c226e223a6e756c6c2c2274223a747275657d",
+      "canonical_byte_length": 29
+    },
+    {
+      "name": "mixed-array",
+      "description": "Array order MUST be preserved (unlike object keys).",
+      "input": [
+        3,
+        1,
+        2,
+        {
+          "b": 2,
+          "a": 1
+        }
+      ],
+      "canonical": "[3,1,2,{\"a\":1,\"b\":2}]",
+      "canonical_bytes_hex": "5b332c312c322c7b2261223a312c2262223a327d5d",
+      "canonical_byte_length": 21
+    },
+    {
+      "name": "deep-nesting",
+      "description": "Multiple levels of nesting still produce stable output.",
+      "input": {
+        "a": {
+          "b": {
+            "c": {
+              "d": {
+                "e": "leaf"
+              }
+            }
+          }
+        }
+      },
+      "canonical": "{\"a\":{\"b\":{\"c\":{\"d\":{\"e\":\"leaf\"}}}}}",
+      "canonical_bytes_hex": "7b2261223a7b2262223a7b2263223a7b2264223a7b2265223a226c656166227d7d7d7d7d",
+      "canonical_byte_length": 36
+    }
+  ]
+}

--- a/tests/vectors/lifecycle/manufacturing.json
+++ b/tests/vectors/lifecycle/manufacturing.json
@@ -1,11 +1,12 @@
 {
-  "description": "Manufacturing track state transitions per Section 9.2.1. Applies to object types: material, component, assembly, system, lot.",
+  "description": "Manufacturing track state transitions per Section 9.2.1. Applies to object types: material, component, assembly, system, lot, design.",
   "object_types": [
     "material",
     "component",
     "assembly",
     "system",
-    "lot"
+    "lot",
+    "design"
   ],
   "states": [
     "concept",

--- a/tests/vectors/lifecycle/manufacturing.json
+++ b/tests/vectors/lifecycle/manufacturing.json
@@ -1,0 +1,426 @@
+{
+  "description": "Manufacturing track state transitions per Section 9.2.1. Applies to object types: material, component, assembly, system, lot.",
+  "object_types": [
+    "material",
+    "component",
+    "assembly",
+    "system",
+    "lot"
+  ],
+  "states": [
+    "concept",
+    "design",
+    "prototype",
+    "qualified",
+    "stock",
+    "deployed",
+    "maintained",
+    "decommissioned",
+    "consumed",
+    "disposed"
+  ],
+  "terminal_states": [
+    "consumed",
+    "disposed"
+  ],
+  "transitions": {
+    "concept": [
+      "design"
+    ],
+    "design": [
+      "prototype",
+      "qualified"
+    ],
+    "prototype": [
+      "design",
+      "qualified"
+    ],
+    "qualified": [
+      "stock",
+      "consumed"
+    ],
+    "stock": [
+      "deployed",
+      "decommissioned",
+      "consumed"
+    ],
+    "deployed": [
+      "maintained",
+      "decommissioned"
+    ],
+    "maintained": [
+      "deployed",
+      "decommissioned"
+    ],
+    "decommissioned": [
+      "consumed",
+      "disposed"
+    ],
+    "consumed": [],
+    "disposed": []
+  },
+  "valid": [
+    {
+      "from": "concept",
+      "to": "design"
+    },
+    {
+      "from": "design",
+      "to": "prototype"
+    },
+    {
+      "from": "design",
+      "to": "qualified"
+    },
+    {
+      "from": "prototype",
+      "to": "design"
+    },
+    {
+      "from": "prototype",
+      "to": "qualified"
+    },
+    {
+      "from": "qualified",
+      "to": "stock"
+    },
+    {
+      "from": "qualified",
+      "to": "consumed"
+    },
+    {
+      "from": "stock",
+      "to": "deployed"
+    },
+    {
+      "from": "stock",
+      "to": "decommissioned"
+    },
+    {
+      "from": "stock",
+      "to": "consumed"
+    },
+    {
+      "from": "deployed",
+      "to": "maintained"
+    },
+    {
+      "from": "deployed",
+      "to": "decommissioned"
+    },
+    {
+      "from": "maintained",
+      "to": "deployed"
+    },
+    {
+      "from": "maintained",
+      "to": "decommissioned"
+    },
+    {
+      "from": "decommissioned",
+      "to": "consumed"
+    },
+    {
+      "from": "decommissioned",
+      "to": "disposed"
+    }
+  ],
+  "invalid": [
+    {
+      "from": "concept",
+      "to": "prototype"
+    },
+    {
+      "from": "concept",
+      "to": "qualified"
+    },
+    {
+      "from": "concept",
+      "to": "stock"
+    },
+    {
+      "from": "concept",
+      "to": "deployed"
+    },
+    {
+      "from": "concept",
+      "to": "maintained"
+    },
+    {
+      "from": "concept",
+      "to": "decommissioned"
+    },
+    {
+      "from": "concept",
+      "to": "consumed"
+    },
+    {
+      "from": "concept",
+      "to": "disposed"
+    },
+    {
+      "from": "design",
+      "to": "concept"
+    },
+    {
+      "from": "design",
+      "to": "stock"
+    },
+    {
+      "from": "design",
+      "to": "deployed"
+    },
+    {
+      "from": "design",
+      "to": "maintained"
+    },
+    {
+      "from": "design",
+      "to": "decommissioned"
+    },
+    {
+      "from": "design",
+      "to": "consumed"
+    },
+    {
+      "from": "design",
+      "to": "disposed"
+    },
+    {
+      "from": "prototype",
+      "to": "concept"
+    },
+    {
+      "from": "prototype",
+      "to": "stock"
+    },
+    {
+      "from": "prototype",
+      "to": "deployed"
+    },
+    {
+      "from": "prototype",
+      "to": "maintained"
+    },
+    {
+      "from": "prototype",
+      "to": "decommissioned"
+    },
+    {
+      "from": "prototype",
+      "to": "consumed"
+    },
+    {
+      "from": "prototype",
+      "to": "disposed"
+    },
+    {
+      "from": "qualified",
+      "to": "concept"
+    },
+    {
+      "from": "qualified",
+      "to": "design"
+    },
+    {
+      "from": "qualified",
+      "to": "prototype"
+    },
+    {
+      "from": "qualified",
+      "to": "deployed"
+    },
+    {
+      "from": "qualified",
+      "to": "maintained"
+    },
+    {
+      "from": "qualified",
+      "to": "decommissioned"
+    },
+    {
+      "from": "qualified",
+      "to": "disposed"
+    },
+    {
+      "from": "stock",
+      "to": "concept"
+    },
+    {
+      "from": "stock",
+      "to": "design"
+    },
+    {
+      "from": "stock",
+      "to": "prototype"
+    },
+    {
+      "from": "stock",
+      "to": "qualified"
+    },
+    {
+      "from": "stock",
+      "to": "maintained"
+    },
+    {
+      "from": "stock",
+      "to": "disposed"
+    },
+    {
+      "from": "deployed",
+      "to": "concept"
+    },
+    {
+      "from": "deployed",
+      "to": "design"
+    },
+    {
+      "from": "deployed",
+      "to": "prototype"
+    },
+    {
+      "from": "deployed",
+      "to": "qualified"
+    },
+    {
+      "from": "deployed",
+      "to": "stock"
+    },
+    {
+      "from": "deployed",
+      "to": "consumed"
+    },
+    {
+      "from": "deployed",
+      "to": "disposed"
+    },
+    {
+      "from": "maintained",
+      "to": "concept"
+    },
+    {
+      "from": "maintained",
+      "to": "design"
+    },
+    {
+      "from": "maintained",
+      "to": "prototype"
+    },
+    {
+      "from": "maintained",
+      "to": "qualified"
+    },
+    {
+      "from": "maintained",
+      "to": "stock"
+    },
+    {
+      "from": "maintained",
+      "to": "consumed"
+    },
+    {
+      "from": "maintained",
+      "to": "disposed"
+    },
+    {
+      "from": "decommissioned",
+      "to": "concept"
+    },
+    {
+      "from": "decommissioned",
+      "to": "design"
+    },
+    {
+      "from": "decommissioned",
+      "to": "prototype"
+    },
+    {
+      "from": "decommissioned",
+      "to": "qualified"
+    },
+    {
+      "from": "decommissioned",
+      "to": "stock"
+    },
+    {
+      "from": "decommissioned",
+      "to": "deployed"
+    },
+    {
+      "from": "decommissioned",
+      "to": "maintained"
+    },
+    {
+      "from": "consumed",
+      "to": "concept"
+    },
+    {
+      "from": "consumed",
+      "to": "design"
+    },
+    {
+      "from": "consumed",
+      "to": "prototype"
+    },
+    {
+      "from": "consumed",
+      "to": "qualified"
+    },
+    {
+      "from": "consumed",
+      "to": "stock"
+    },
+    {
+      "from": "consumed",
+      "to": "deployed"
+    },
+    {
+      "from": "consumed",
+      "to": "maintained"
+    },
+    {
+      "from": "consumed",
+      "to": "decommissioned"
+    },
+    {
+      "from": "consumed",
+      "to": "disposed"
+    },
+    {
+      "from": "disposed",
+      "to": "concept"
+    },
+    {
+      "from": "disposed",
+      "to": "design"
+    },
+    {
+      "from": "disposed",
+      "to": "prototype"
+    },
+    {
+      "from": "disposed",
+      "to": "qualified"
+    },
+    {
+      "from": "disposed",
+      "to": "stock"
+    },
+    {
+      "from": "disposed",
+      "to": "deployed"
+    },
+    {
+      "from": "disposed",
+      "to": "maintained"
+    },
+    {
+      "from": "disposed",
+      "to": "decommissioned"
+    },
+    {
+      "from": "disposed",
+      "to": "consumed"
+    }
+  ]
+}

--- a/tests/vectors/lifecycle/operational.json
+++ b/tests/vectors/lifecycle/operational.json
@@ -1,0 +1,85 @@
+{
+  "description": "Operational track state transitions per Section 9.3.1. Applies to object types: actor, location, vehicle. Archived objects MAY accept `note` events; all other terminal states reject every event.",
+  "object_types": [
+    "actor",
+    "location",
+    "vehicle"
+  ],
+  "states": [
+    "planned",
+    "active",
+    "inactive",
+    "archived"
+  ],
+  "terminal_states": [
+    "archived"
+  ],
+  "archived_accepts_note": true,
+  "transitions": {
+    "planned": [
+      "active",
+      "archived"
+    ],
+    "active": [
+      "inactive",
+      "archived"
+    ],
+    "inactive": [
+      "active",
+      "archived"
+    ],
+    "archived": []
+  },
+  "valid": [
+    {
+      "from": "planned",
+      "to": "active"
+    },
+    {
+      "from": "planned",
+      "to": "archived"
+    },
+    {
+      "from": "active",
+      "to": "inactive"
+    },
+    {
+      "from": "active",
+      "to": "archived"
+    },
+    {
+      "from": "inactive",
+      "to": "active"
+    },
+    {
+      "from": "inactive",
+      "to": "archived"
+    }
+  ],
+  "invalid": [
+    {
+      "from": "planned",
+      "to": "inactive"
+    },
+    {
+      "from": "active",
+      "to": "planned"
+    },
+    {
+      "from": "inactive",
+      "to": "planned"
+    },
+    {
+      "from": "archived",
+      "to": "planned"
+    },
+    {
+      "from": "archived",
+      "to": "active"
+    },
+    {
+      "from": "archived",
+      "to": "inactive"
+    }
+  ]
+}

--- a/tests/vectors/self-check.js
+++ b/tests/vectors/self-check.js
@@ -1,0 +1,207 @@
+// Self-check for the committed test vectors.
+//
+// Loads each fixture from disk and verifies it passes the checks that any
+// client-library implementation is expected to perform:
+//
+//   * JCS — canonicalize(input) === canonical, and its UTF-8 bytes == canonical_bytes_hex
+//   * Hash — "sha256:" + SHA-256(canonical bytes) === hash
+//   * Ed25519 — signing the message with the private key yields signature_b64url,
+//     and verifying with the public key returns true
+//   * Hash chain — each event's previous_hash equals hash(previous event)
+//   * Bootstrap — the self-signed created event verifies against the public key
+//     embedded in its own payload
+//
+// If this script passes, the committed fixtures are internally consistent and
+// any other implementation that produces identical output is byte-compatible.
+// Run `node vectors/self-check.js` from the tests/ directory.
+
+"use strict";
+
+const crypto = require("node:crypto");
+const fs = require("node:fs");
+const path = require("node:path");
+const canonicalize = require("canonicalize");
+
+const VEC = __dirname;
+
+let pass = 0;
+let fail = 0;
+
+function assert(cond, label) {
+  if (cond) {
+    pass++;
+    console.log(`  ok  ${label}`);
+  } else {
+    fail++;
+    console.log(`  FAIL ${label}`);
+  }
+}
+
+function load(rel) {
+  return JSON.parse(fs.readFileSync(path.join(VEC, rel), "utf8"));
+}
+
+function sha256Hex(buf) {
+  return crypto.createHash("sha256").update(buf).digest("hex");
+}
+
+function hashEvent(event) {
+  return "sha256:" + sha256Hex(Buffer.from(canonicalize(event), "utf8"));
+}
+
+function loadKey(kp) {
+  const privateKey = crypto.createPrivateKey({
+    key: Buffer.from(kp.private_pkcs8_b64, "base64"),
+    format: "der",
+    type: "pkcs8",
+  });
+  const raw = Buffer.from(kp.public_raw_b64url, "base64url");
+  const spki = Buffer.concat([
+    Buffer.from("302a300506032b6570032100", "hex"),
+    raw,
+  ]);
+  const publicKey = crypto.createPublicKey({
+    key: spki,
+    format: "der",
+    type: "spki",
+  });
+  return { privateKey, publicKey };
+}
+
+// ── JCS ─────────────────────────────────────────────────────────────
+console.log("\n[jcs]");
+{
+  const { cases } = load("jcs/cases.json");
+  for (const c of cases) {
+    const canonical = canonicalize(c.input);
+    assert(canonical === c.canonical, `${c.name} canonical matches`);
+    const hex = Buffer.from(canonical, "utf8").toString("hex");
+    assert(hex === c.canonical_bytes_hex, `${c.name} byte-hex matches`);
+  }
+}
+
+// ── Hash ────────────────────────────────────────────────────────────
+console.log("\n[hash]");
+{
+  const { cases } = load("hash/cases.json");
+  for (const c of cases) {
+    const got = "sha256:" + sha256Hex(Buffer.from(canonicalize(c.input), "utf8"));
+    assert(got === c.hash, `${c.name} hash matches`);
+  }
+}
+
+// ── Ed25519 ─────────────────────────────────────────────────────────
+console.log("\n[ed25519]");
+{
+  const { keys } = load("ed25519/keypair.json");
+  const keyMap = Object.fromEntries(keys.map((k) => [k.id, loadKey(k)]));
+  const { raw, events } = load("ed25519/cases.json");
+
+  for (const c of raw) {
+    const key = keyMap[c.key_id];
+    const msg = Buffer.from(c.message_hex, "hex");
+    const sig = crypto.sign(null, msg, key.privateKey);
+    assert(
+      sig.toString("base64url") === c.signature_b64url,
+      `raw ${c.name} signature reproduces`
+    );
+    assert(
+      crypto.verify(null, msg, key.publicKey, Buffer.from(c.signature_b64url, "base64url")),
+      `raw ${c.name} signature verifies`
+    );
+  }
+
+  for (const c of events) {
+    const key = keyMap[c.key_id];
+    const canonical = canonicalize(c.event_unsigned);
+    const hex = Buffer.from(canonical, "utf8").toString("hex");
+    assert(hex === c.canonical_bytes_hex, `event ${c.name} canonical bytes match`);
+    const sig = crypto.sign(null, Buffer.from(canonical, "utf8"), key.privateKey);
+    assert(
+      sig.toString("base64url") === c.signature_b64url,
+      `event ${c.name} signature reproduces`
+    );
+    const { signature, ...rest } = c.signed_event;
+    const verified = crypto.verify(
+      null,
+      Buffer.from(canonicalize(rest), "utf8"),
+      key.publicKey,
+      Buffer.from(signature.value, "base64url")
+    );
+    assert(verified, `event ${c.name} signed_event verifies`);
+  }
+}
+
+// ── Hash chain ──────────────────────────────────────────────────────
+console.log("\n[hashchain]");
+{
+  const { events, expected_hashes } = load("hashchain/sequence.json");
+  for (let i = 0; i < events.length; i++) {
+    const ev = events[i];
+    if (i === 0) {
+      assert(ev.previous_hash === "genesis", `event[0] previous_hash is "genesis"`);
+    } else {
+      const expected = hashEvent(events[i - 1]);
+      assert(
+        ev.previous_hash === expected,
+        `event[${i}].previous_hash equals hash(event[${i - 1}])`
+      );
+    }
+    const got = hashEvent(ev);
+    assert(got === expected_hashes[i], `event[${i}] hash matches expected_hashes[${i}]`);
+  }
+}
+
+// ── Bootstrap ──────────────────────────────────────────────────────
+console.log("\n[bootstrap]");
+{
+  const { created_event, bootstrap_actor_id } = load("bootstrap/example.json");
+  const embeddedJwk = created_event.payload.attributes["phip:keys"];
+  assert(embeddedJwk.kty === "OKP" && embeddedJwk.crv === "Ed25519", "JWK kty+crv");
+  const raw = Buffer.from(embeddedJwk.x, "base64url");
+  const spki = Buffer.concat([
+    Buffer.from("302a300506032b6570032100", "hex"),
+    raw,
+  ]);
+  const publicKey = crypto.createPublicKey({
+    key: spki,
+    format: "der",
+    type: "spki",
+  });
+  const { signature, ...rest } = created_event;
+  const verified = crypto.verify(
+    null,
+    Buffer.from(canonicalize(rest), "utf8"),
+    publicKey,
+    Buffer.from(signature.value, "base64url")
+  );
+  assert(verified, "bootstrap event verifies against its own embedded public key");
+  assert(
+    created_event.actor === bootstrap_actor_id &&
+      created_event.phip_id === bootstrap_actor_id,
+    "bootstrap actor equals phip_id (self-signed)"
+  );
+}
+
+// ── Lifecycle sanity ────────────────────────────────────────────────
+console.log("\n[lifecycle]");
+{
+  for (const file of ["lifecycle/manufacturing.json", "lifecycle/operational.json"]) {
+    const v = load(file);
+    for (const t of v.valid) {
+      assert(
+        (v.transitions[t.from] || []).includes(t.to),
+        `${file} valid[${t.from}→${t.to}] present in transitions table`
+      );
+    }
+    for (const t of v.invalid) {
+      assert(
+        !(v.transitions[t.from] || []).includes(t.to),
+        `${file} invalid[${t.from}→${t.to}] absent from transitions table`
+      );
+    }
+  }
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail === 0 ? 0 : 1);

--- a/tests/vectors/uri/cases.json
+++ b/tests/vectors/uri/cases.json
@@ -1,0 +1,62 @@
+{
+  "description": "PhIP URI parsing per Section 4. Valid URIs decompose into authority, namespace, local_id, and optional sub_path (array of path segments after local_id, if any). Invalid URIs MUST be rejected.",
+  "valid": [
+    {
+      "uri": "phip://acme.example/parts/widget-001",
+      "authority": "acme.example",
+      "namespace": "parts",
+      "local_id": "widget-001",
+      "sub_path": []
+    },
+    {
+      "uri": "phip://acme.example/parts/widget-001/sensors/temp-1",
+      "authority": "acme.example",
+      "namespace": "parts",
+      "local_id": "widget-001",
+      "sub_path": [
+        "sensors",
+        "temp-1"
+      ]
+    },
+    {
+      "uri": "phip://sub.acme.example/lots/LOT-2026-04-001",
+      "authority": "sub.acme.example",
+      "namespace": "lots",
+      "local_id": "LOT-2026-04-001",
+      "sub_path": []
+    },
+    {
+      "uri": "phip://acme-mfg.co.uk/racks/R1.A.07",
+      "authority": "acme-mfg.co.uk",
+      "namespace": "racks",
+      "local_id": "R1.A.07",
+      "sub_path": []
+    }
+  ],
+  "invalid": [
+    {
+      "uri": "http://acme.example/parts/x",
+      "reason": "wrong scheme"
+    },
+    {
+      "uri": "phip:/acme.example/parts/x",
+      "reason": "missing //"
+    },
+    {
+      "uri": "phip://acme.example/parts",
+      "reason": "missing local-id segment"
+    },
+    {
+      "uri": "phip://acme.example//widget",
+      "reason": "empty namespace segment"
+    },
+    {
+      "uri": "phip:///parts/widget",
+      "reason": "empty authority"
+    },
+    {
+      "uri": "phip://acme example/parts/x",
+      "reason": "space in authority"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Closes the entire v0.1 open-issues backlog (5 High + 12 Medium + 5 Low → 0 remaining) and adds the test infrastructure required for multi-language client libraries (`phip-js`, `phip-py`, etc.).

Two commits, organized by severity tier:
- `81f7a71` — interop tests + High and Medium spec resolutions
- `7e6f129` — Low spec resolutions

Spec grows from ~1.5k lines to ~3.2k. CHANGELOG documents every section touched.

## Interop prerequisites

- **`tests/vectors/`** — language-agnostic fixtures locking down the wire format. JCS canonicalization, SHA-256 hash encoding, Ed25519 sign/verify, URI parsing, hash-chain continuity, lifecycle transitions, and self-signed bootstrap. Deterministic, regenerable, 160-assertion self-check.
- **`tests/conformance/`** — black-box HTTP suite for any PhIP server. CREATE/GET/PUSH/QUERY/history/error envelopes. 35 assertions, all pass against the reference resolver.

A client library (in any language) is byte-compatible with the reference iff it produces identical output on every fixture.

## Spec resolutions — High severity

| # | Where it lives now |
|---|---|
| **A1** Sub-object addressing | §4.4: field-replaceable rule, no lifecycle inheritance, `contained_in` is normative |
| **A13** Design revision model | New `design` object type (§6.2), `instance_of` retargeting (§6.3), `supersedes`/`superseded_by` relations |
| **A23** Authority transfer / domain death | §4.6: root key, `authority_transfer` event, mirror_urls, redirect exception |
| **A26** Read access control | New `phip:access` namespace + `schemas/access.json`, read scopes on capability tokens, `ACCESS_DENIED` (403) |
| **A27** Privacy / GDPR | New §15 annex: no-raw-PII rule, `phip:personal_data` salted commitments, salt deletion as erasure mechanism |

## Spec resolutions — Medium severity

| # | Where it lives now |
|---|---|
| **A2** Yield fraction math | §10.4.1, §10.4.2: `[0,1]` per-input sum ≤ 1 + ε |
| **A3** Geographic position | New `phip:geo` namespace + `schemas/geo.json` |
| **A4** Multi-party custody | §11.3.7: prior → carrier → next custodian token chain |
| **A5** Lot mass conservation | §10.5.1: tolerance, optional `loss_quantity`, unit-mismatch handling |
| **A6** Measurement payload | §11.4.2: `metric`/`value`/`unit`/`as_of`/`thresholds`/`outcome`/`external_ref` |
| **A12** Authority delegation | §4.5.1–4.5.5: `delegations` array in `/meta` |
| **A14** Lot fungibility | §6.4: required `fungible` boolean on lot identity |
| **A15** Lot quantity tracking | §6.4.1: `identity.quantity` + partial draw-down via `attribute_update` |
| **A16** Regulatory jurisdiction | `phip:compliance` extended with jurisdiction/authority/applicable/export_control |
| **A18** Uncertainty qualifiers | §5.2.1: `<field>_quality` convention |
| **A29** Bidirectional cross-org | §7.3: relations owned by writing object; cross-authority inverses optional |
| **A30** Dangling relations | §7.4 + new `DANGLING_RELATION` (422) |

## Spec resolutions — Low severity

| # | Where it lives now |
|---|---|
| **A33** Batch operations | New §12.5: non-atomic CREATE/PUSH batch, 1000-event cap, 207 Multi-Status |
| **A34** Offline / air-gapped | §4.3.4: signed PhIP bundle format + warm cache + replay-on-reconnect |
| **A35** HTTP authentication | §12.8: PhIP-Capability is canonical, mTLS overlay, non-protocol endpoints unrestricted |
| **A36** Conformance levels | §13 split into Full/Read-Only/Mirror/Client-Only + `WRITE_NOT_SUPPORTED` (405) |
| **A37** Schema versioning | §8.4 semver MAJOR.MINOR; all schemas seeded `version: "1.0"` |

## A10 (originally bundled with tests)

Section 4.3 fully fleshed out: 4.3.1 (no DNS TXT/SRV), 4.3.2 (ETag/Cache-Control), 4.3.3 (same-authority redirects), and new Section 12.7 metadata document.

## Schema changes

- New: `schemas/access.json`, `schemas/geo.json`
- Updated: `schemas/compliance.json` (jurisdiction + export_control), all schemas seeded `version: "1.0"`

## New error codes

`ACCESS_DENIED` (403) · `DANGLING_RELATION` (422) · `WRITE_NOT_SUPPORTED` (405)

## New event types

`authority_transfer` (signed by root authority key)

## New object type

`design` (manufacturing track)

## New relations

`supersedes` / `superseded_by` (between design revisions)

## Section renumbering in §12

`12.5 Error Responses → 12.6`, `12.6 Metadata Document → 12.7`. New `12.5 Batch Operations` and `12.8 HTTP Authentication`. All cross-references updated.

## Test plan

- [x] Reference resolver smoke test passes (in-memory + HTTP round trip)
- [x] Vector self-check passes (160/160 assertions)
- [x] HTTP conformance suite passes against reference (35/35)
- [x] All seven JSON schemas validate against ajv (5 access cases + 8 compliance/geo cases)
- [x] Open-issues count reaches 0
- [ ] Reviewer: re-read §15 (privacy) for legal-risk framing
- [ ] Reviewer: spot-check Section 12 cross-references after the renumber
- [ ] Reviewer: confirm A23 root-key model is workable for real-world authority transfers

🤖 Generated with [Claude Code](https://claude.com/claude-code)