### PR TITLE
Library prerequisites: schemas, vectors, spec sections, @phip/conformance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -139,6 +139,5 @@ from sharp critique; humans don't.
 
 ## Questions
 
-For questions that aren't quite issues yet:
-- GitHub Discussions on this repo
-- Email the maintainers (see README)
+For questions that aren't quite issues yet, open a GitHub Discussion
+on this repo.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,17 +77,19 @@ PRs that change normative spec text SHOULD include:
 ## Scope rules
 
 This repo is intentionally minimal. The following are out of scope here
-and should be raised in the appropriate sibling repo:
+and should be raised in the appropriate sibling repo (note: most sibling
+repos are planned but not yet created; until they exist, file the issue
+on this repo with the prefix `[future-repo]:` and we'll triage):
 
-| Concern | Repo |
-|---|---|
-| Client library bugs / features | `phip-js`, `phip-py`, `phip-rs` etc. |
-| Production server features | `phip-server` |
-| Operator CLI features | `phip-cli` |
-| Vertical examples | `phip-datacenter`, etc. |
-| Persistence backends | `phip-server` |
-| HSM / KMS integration | `phip-cli` |
-| TLS / mTLS termination | `phip-server` |
+| Concern | Repo | Status |
+|---|---|---|
+| Client library bugs / features | `phip-js`, `phip-py`, `phip-rs` etc. | planned |
+| Production server features | `phip-server` | planned |
+| Operator CLI features | `phip-cli` | planned |
+| Vertical examples | `phip-datacenter`, etc. | planned |
+| Persistence backends | `phip-server` | planned |
+| HSM / KMS integration | `phip-cli` | planned |
+| TLS / mTLS termination | `phip-server` | planned |
 
 ## The reference resolver is not the production server
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,142 @@
+# Contributing to PhIP
+
+The PhIP repo holds the specification, JSON schemas, language-agnostic
+test vectors, the HTTP conformance suite, and a minimal reference
+resolver. Client libraries (`phip-js`, `phip-py`, `phip-rs`, ...) and
+the production server (`phip-server`) live in their own repositories
+under [github.com/mfgs-us](https://github.com/mfgs-us).
+
+This guide covers contributing to **this** repo. For language-specific
+libraries, see the CONTRIBUTING file in each lib's repo.
+
+## What lives here
+
+| Directory | Purpose |
+|---|---|
+| `spec/` | The specification — `phip-core.md` is normative, `CHANGELOG.md` tracks revisions |
+| `schemas/` | JSON Schemas: core object, attribute namespaces, capability token, /meta document, bundle manifest, authority-transfer payload |
+| `tests/vectors/` | Language-agnostic fixtures — JCS canonicalization, Ed25519, hash chain, lifecycle, tokens, bundles |
+| `tests/conformance/` | HTTP black-box test suite for any PhIP server |
+| `reference/` | Minimal Node reference resolver — pedagogical and spec-validation only, NOT a production server |
+
+## Quick start
+
+```bash
+# Install reference + tests dependencies
+cd reference && npm install
+cd ../tests && npm install
+
+# Run reference's smoke + federation tests
+cd ../reference && npm test
+
+# Validate the language-agnostic vectors
+cd ../tests && npm run self-check
+
+# Run the HTTP conformance suite against a running reference
+cd ../reference && PHIP_AUTHORITY=test.local PHIP_PORT=8080 npm start &
+cd ../tests && npm run conformance -- http://127.0.0.1:8080 --authority test.local
+```
+
+All four commands MUST pass before you submit a PR.
+
+## Filing an issue
+
+Before filing:
+
+- For **spec questions**, search the spec text and Appendix A first. If
+  your question reveals an ambiguity or gap, the issue title should
+  start with `spec:`.
+- For **schema bugs**, include the JSON Schema validation error and the
+  input that triggered it.
+- For **conformance suite bugs**, include the resolver under test and
+  the failing assertion's full output.
+- For **reference resolver bugs**, include `node --version`, the env
+  vars passed, and a minimal reproduction.
+
+## Pull request checklist
+
+Every PR MUST:
+
+- [ ] Pass `cd reference && npm test`
+- [ ] Pass `cd tests && npm run self-check`
+- [ ] Pass `cd tests && npm run conformance -- ...` against the reference
+- [ ] Update `spec/CHANGELOG.md` if the change touches the spec
+- [ ] Update the `version` field in any modified schema (per `VERSIONING.md`)
+- [ ] Add or update a fixture in `tests/vectors/` if the change affects
+      the wire format
+- [ ] Add or update an assertion in `tests/conformance/` if the change
+      affects an HTTP-visible behavior
+
+PRs that change normative spec text SHOULD include:
+
+- The motivation (what real-world scenario surfaced the issue)
+- A link to the relevant Appendix A entry, or a new Appendix A entry
+  if this raises a new issue
+- A test vector or conformance assertion locking in the new behavior
+
+## Scope rules
+
+This repo is intentionally minimal. The following are out of scope here
+and should be raised in the appropriate sibling repo:
+
+| Concern | Repo |
+|---|---|
+| Client library bugs / features | `phip-js`, `phip-py`, `phip-rs` etc. |
+| Production server features | `phip-server` |
+| Operator CLI features | `phip-cli` |
+| Vertical examples | `phip-datacenter`, etc. |
+| Persistence backends | `phip-server` |
+| HSM / KMS integration | `phip-cli` |
+| TLS / mTLS termination | `phip-server` |
+
+## The reference resolver is not the production server
+
+`reference/` is intentionally small. It exists to:
+
+1. Validate that the spec, as written, can be implemented
+2. Serve as the conformance suite's target during spec changes
+3. Give spec readers a working example they can read end-to-end
+
+It does NOT have:
+- Persistent storage (everything is in-memory)
+- TLS termination (operators front it with a TLS-terminating proxy)
+- Production observability
+- HSM/KMS integration
+
+Pull requests adding any of the above will be redirected to
+`phip-server`.
+
+## Spec change process
+
+Substantive spec changes follow this flow:
+
+1. **File an issue** describing the gap or ambiguity. Get rough
+   agreement that the change is needed.
+2. **Open a PR** with the spec text change, schema updates if any,
+   test vector updates if any, conformance suite updates if any, and
+   a CHANGELOG entry.
+3. **Review** focuses on: spec internal consistency, conformance with
+   existing sections, test coverage of the new behavior, impact on
+   the reference resolver.
+4. **Merge** after review approval and all checks pass.
+
+Editorial changes (typos, rewording, clarifying examples) can skip
+step 1.
+
+## Appendix A — open issues
+
+The spec's Appendix A is the canonical list of open spec issues.
+Resolved items are crossed out with a one-line summary and a section
+reference. New issues raised in PRs SHOULD be added to Appendix A
+under §A.2 (Open Issues — Post-v0.1) with a severity rating.
+
+## Code of conduct
+
+Be civil. Disagree with code, not with people. The protocol benefits
+from sharp critique; humans don't.
+
+## Questions
+
+For questions that aren't quite issues yet:
+- GitHub Discussions on this repo
+- Email the maintainers (see README)

--- a/IMPLEMENTATIONS.md
+++ b/IMPLEMENTATIONS.md
@@ -1,0 +1,60 @@
+# PhIP Implementations
+
+Known PhIP implementations and their conformance status. To add an
+entry, open a PR — at minimum the implementation MUST pass the
+language-agnostic vectors (`tests/vectors/`) and (for resolvers) the
+HTTP conformance suite (`tests/conformance/`).
+
+## Resolvers
+
+Implementations that **host** PhIP objects.
+
+| Implementation | Language | Class | Spec | Vectors | HTTP | Federation | Notes |
+|---|---|---|---|---|---|---|---|
+| [phip reference](./reference) | Node 20+ | Full | 0.1.0-draft | 189/189 | 76/76 | 30/30 | In-tree; pedagogical, in-memory only, NOT for production |
+
+Conformance class definitions are in spec §13.
+
+## Client libraries
+
+Implementations that **consume** PhIP via HTTP.
+
+| Implementation | Language | Spec | Vectors | Status |
+|---|---|---|---|---|
+| _(none yet — `phip-js` and `phip-py` are next)_ | | | | |
+
+## How to claim conformance
+
+A new implementation claims conformance by:
+
+1. **Passing the language-agnostic vectors** (`tests/vectors/self-check.js`
+   if you ported the harness to your language; otherwise re-implement
+   the assertions and compare byte-for-byte against each fixture).
+2. **For resolvers**, passing the HTTP conformance suite — install
+   `@phip/conformance` and run it against a live instance.
+3. **For federated resolvers**, additionally passing the federation
+   conformance suite covering cross-authority token verification,
+   delegation, and transfer.
+
+Add a row to the table above with:
+- Direct link to the implementation
+- Language and runtime
+- Conformance class (resolver) or "Client" (lib)
+- Spec version targeted
+- Test pass count (e.g. `189/189`)
+- Notes on production readiness
+
+## Why this list matters
+
+For a federated protocol, implementation diversity is a goal — multiple
+servers and clients prove the spec is not accidentally tied to one
+codebase. This list is the public record of who has done what and
+makes it easy for new integrators to find a library in their language.
+
+## Reporting a broken implementation
+
+If an implementation listed here has stopped passing conformance, file
+an issue and we will mark it as such. Implementations remain on the
+list (with a note) for at least 90 days after a regression to give
+maintainers time to fix; persistently broken implementations are
+removed.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,173 @@
-# PhIP - Physical Information Protocol
+# PhIP — Physical Information Protocol
 
-A protocol for formatting, querying, sending, and receiving, information for physical objects at any point during the design and manufacturing processes.
+A federated protocol for formatting, addressing, querying, and exchanging
+information about physical objects across organizational and system
+boundaries — at any point during design, manufacturing, deployment, or
+end-of-life.
+
+PhIP is to physical objects what HTTP/DNS was to documents: a universal
+addressing and exchange protocol. It is **not** an ERP, MES, file format,
+communication bus, or blockchain.
+
+> **Status:** `0.1.0-draft`. The protocol is implementable but not stable
+> — minor versions may introduce breaking changes until the spec hits 1.0.
+> See [`VERSIONING.md`](./VERSIONING.md).
+
+## Quick links
+
+| Document | What it is |
+|---|---|
+| [**spec/phip-core.md**](./spec/phip-core.md) | The full normative specification |
+| [**spec/CHANGELOG.md**](./spec/CHANGELOG.md) | What changed in each revision |
+| [**schemas/**](./schemas/) | JSON Schemas: core object, attribute namespaces, capability tokens, /meta, bundle manifest |
+| [**tests/conformance/**](./tests/conformance/) | Black-box HTTP conformance suite — `npm install -g @phip/conformance` |
+| [**tests/vectors/**](./tests/vectors/) | Language-agnostic test fixtures: JCS, Ed25519, hash chains, lifecycle, tokens, bundles |
+| [**reference/**](./reference/) | Minimal Node reference resolver (pedagogical; not a production server) |
+| [**IMPLEMENTATIONS.md**](./IMPLEMENTATIONS.md) | Registry of known implementations and conformance status |
+| [**CONTRIBUTING.md**](./CONTRIBUTING.md) | How to file issues and submit PRs |
+| [**VERSIONING.md**](./VERSIONING.md) | Spec, schema, and library versioning rules |
+
+## What problem PhIP solves
+
+Cross-organizational provenance for physical things. Today, when a part
+moves between Apple → Foxconn → Quanta → a datacenter operator → a
+recycler, every handoff loses or rewrites information. There is no
+universal way to say "this object's history is at this URL, signed by
+these parties, verifiable end-to-end" — so each organization stores
+its own incompatible record, and provenance evaporates at every
+boundary.
+
+PhIP defines:
+
+- **Identity** — a federated URI scheme (`phip://{authority}/{namespace}/{local-id}`)
+  resolvable via a well-known HTTPS endpoint
+- **Object model** — four required fields (`phip_id`, `object_type`,
+  `state`, `history`) shared by every PhIP object
+- **Schema namespaces** — extensible typed attributes
+  (`phip:mechanical`, `phip:datacenter`, `phip:software`,
+  `phip:compliance`, `phip:geo`, `phip:access`)
+- **Lifecycle state machine** — enforced transitions across two tracks:
+  manufacturing (`concept` → `design` → … → `disposed`) and
+  operational (`planned` → `active` → `inactive` → `archived`)
+- **Trust model** — Ed25519-signed events, hash-chained append-only
+  history, capability tokens for cross-org writes, foreign-authority
+  key resolution for cross-org token verification
+- **Federation primitives** — authority delegation (sub-namespace
+  hand-off), authority transfer (acquisition / domain death),
+  mirror snapshots (archival)
+
+All data crosses the wire as canonical JSON (RFC 8785), all events
+carry verifiable signatures, all writes go through an enforced state
+machine.
+
+## Architecture in five layers
+
+| Layer | What it does |
+|---|---|
+| **5. Trust** | Ed25519 event signing, hash-chained history, capability tokens, mTLS / RFC 9421 caller authentication |
+| **4. Lifecycle** | State machine; enforced transitions; terminal states |
+| **3. Schema namespaces** | Domain-specific typed attributes (`phip:datacenter`, `phip:mechanical`, …) |
+| **2. Object model** | Required fields; event log structure; history projection |
+| **1. Identity** | URI scheme, resolver discovery, redirect/transfer/delegation rules |
+
+Protocol operations: `CREATE`, `GET`, `PUSH`, `QUERY`, `history`,
+`batch_create`, `batch_push`, `meta` — all over HTTPS.
+
+## Try it
+
+### Run the reference resolver
+
+```bash
+cd reference
+npm install
+PHIP_AUTHORITY=test.local PHIP_PORT=8080 npm start
+```
+
+In another terminal, prove it works:
+
+```bash
+cd tests/conformance
+node run.js http://127.0.0.1:8080 --authority test.local
+# 76 passed, 0 failed
+```
+
+### Validate any other PhIP server
+
+If you've built a PhIP server in another language, install the
+conformance suite globally and probe your server:
+
+```bash
+npm install -g @phip/conformance
+phip-conformance http://my-resolver.example --authority my-authority.example
+```
+
+### Read the test vectors
+
+The fixtures in [`tests/vectors/`](./tests/vectors/) are language-agnostic.
+Any client library that produces byte-identical output on these inputs
+is wire-compatible with the reference. Implementing PhIP in a new
+language? Start there.
+
+## Implementations
+
+See [**IMPLEMENTATIONS.md**](./IMPLEMENTATIONS.md) for the current
+registry. To add yours, open a PR after passing the vectors and (for
+servers) the conformance suite.
+
+Planned first-party implementations under
+[github.com/mfgs-us](https://github.com/mfgs-us):
+
+- `phip-py` — Python client library
+- `phip-rs` — Rust client library (no_std-friendly for embedded)
+- `phip-server` — production server (Go, single binary)
+- `phip-cli` — operator CLI (Go)
+- `phip-js` — JavaScript / TypeScript client library
+- `phip-datacenter` — vertical example application
+
+The `phip` repo (this one) holds the spec, schemas, conformance suite,
+test vectors, and a minimal reference. Everything else lives in its
+own repo.
+
+## Repository layout
+
+```
+phip/
+├── spec/              # The specification — phip-core.md is normative
+├── schemas/           # JSON Schemas (object, namespaces, tokens, meta, bundle)
+├── tests/
+│   ├── vectors/       # Language-agnostic fixtures
+│   └── conformance/   # HTTP conformance suite (also @phip/conformance)
+├── reference/         # Minimal Node reference resolver
+├── README.md
+├── CONTRIBUTING.md
+├── VERSIONING.md
+├── IMPLEMENTATIONS.md
+└── LICENSE
+```
+
+The reference resolver in `reference/` is intentionally minimal — no
+persistence, no TLS, no HSM integration. It exists to validate the
+spec and serve as a working example for spec readers. Production
+deployments use `phip-server` (a separate repo, when it lands).
+
+## Contributing
+
+See [**CONTRIBUTING.md**](./CONTRIBUTING.md). The PR checklist requires
+passing:
+
+- `cd reference && npm test` — reference smoke + federation
+- `cd tests && npm run self-check` — language-agnostic vectors (189
+  assertions)
+- `cd tests/conformance && node run.js <url>` — HTTP conformance suite
+  against a running resolver (76 assertions plus federation §20)
+
+Spec changes should reference an Appendix A entry. Editorial changes
+can skip the issue step.
+
+## License
+
+Apache 2.0. See [`LICENSE`](./LICENSE).
+
+## Repository
+
+[github.com/mfgs-us/phip](https://github.com/mfgs-us/phip)

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -94,7 +94,11 @@ both v0.1 and v0.2 resolvers). Across MAJOR boundaries (e.g.,
 v0.x ↔ v1.x), libraries pick a side and document which.
 
 Operators following spec §8.4.6 must support N-1 MAJOR for at least
-12 months. Libraries SHOULD aim for the same window where practical.
+12 months. Libraries MUST document their actual support window in
+their README; SHOULD aim for the same 12-month N-1 window where
+maintainer resources allow. A single-author library that can only
+target the current MAJOR is acceptable as long as the README is
+explicit — adopters can plan around it.
 
 ## Schema namespace versioning vs. spec versioning
 

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -1,0 +1,139 @@
+# Versioning Policy
+
+This document defines the versioning rules for the PhIP specification,
+the schemas, and the client libraries that implement them. The same
+rules apply to every PhIP package across every language.
+
+## Spec versioning
+
+The PhIP Core Specification (`spec/phip-core.md`) is versioned with a
+single semver-style string carried in `protocol_version`:
+
+```
+MAJOR . MINOR . PATCH (- prerelease)?
+```
+
+- **MAJOR** — incompatible wire-format change (new required field on
+  events, removal of an event type, change to canonicalization rules,
+  change to hash algorithm). Bumped only with strong justification.
+- **MINOR** — backward-compatible additive change (new optional field
+  on events, new event type, new error code, new endpoint, new
+  conformance class). v0.1 implementations MUST continue to interoperate
+  with v0.2 resolvers for the operations they both support.
+- **PATCH** — clarification, typo fix, schema-equivalent rephrasing.
+  No implementation changes required.
+- **prerelease** — `-draft`, `-rc.1`, etc. The current spec is
+  `0.1.0-draft` and remains so until the spec is declared stable.
+
+Resolvers advertise their target spec version via
+`/.well-known/phip/meta.protocol_version`. Clients SHOULD warn (not
+fail) on MAJOR mismatch, since most operations remain compatible
+across MAJOR boundaries when the resolver maintains backward
+compatibility.
+
+## Schema versioning
+
+Each JSON Schema file under `schemas/` carries its own `version` field
+and follows the same rules described in spec §8.4 (Schema Versioning).
+In summary:
+
+- Additive changes (new optional property, new enum value) → MINOR bump.
+- Breaking changes (removed property, narrowed validation, type change)
+  → MAJOR bump.
+- Documentation-only changes don't bump the schema version.
+
+The unversioned URL (`schemas/mechanical.json`) MUST resolve to the
+latest stable version. Pinned consumers use the versioned URL
+(`schemas/mechanical/v1.2.json`).
+
+Schema MAJOR versions are independent of spec MAJOR versions —
+`phip:mechanical` v2.0 can ship under PhIP spec v0.1.
+
+## Library versioning
+
+Every PhIP client library (`phip-js`, `phip-py`, `phip-rs`, etc.) MUST
+follow these rules:
+
+### Pin to spec MAJOR
+
+A library at version `X.Y.Z` implements PhIP spec `X.*.*`. PhIP spec
+v1.0 → library v1.x.y. PhIP spec v2.0 → library v2.x.y. Libraries
+SHOULD NOT support multiple spec MAJOR versions simultaneously; the
+12-month compatibility window in §8.4.6 applies to **operators**
+deploying resolvers, not to libraries.
+
+### Library MINOR tracks spec MINOR
+
+When the spec adds a new event type or endpoint (a MINOR bump), the
+library bumps its own MINOR version once it implements the new
+surface. Libraries MAY ship MINOR-version-behind support — a library
+at v0.1.5 implementing PhIP v0.1.0 is fine, as long as it doesn't
+silently drop fields it doesn't recognize.
+
+### Library PATCH for internal changes
+
+Bug fixes, performance improvements, dependency bumps, internal
+refactors that don't change the lib's public API → PATCH bump.
+
+### Public API breaking change
+
+A library's own public API can break independently of the spec:
+
+- Lib at `0.x.y` may break the public API on any MINOR bump.
+- Lib at `1.x.y` and above MUST follow strict SemVer for public-API
+  changes: breaking change → MAJOR bump.
+
+When a public-API break and a spec MAJOR change happen together, both
+bump simultaneously and the changelog explains both.
+
+### Compatibility window
+
+Libraries SHOULD support at least the current and previous spec
+MINOR within a single major (e.g., v0.1 lib supports talking to
+both v0.1 and v0.2 resolvers). Across MAJOR boundaries (e.g.,
+v0.x ↔ v1.x), libraries pick a side and document which.
+
+Operators following spec §8.4.6 must support N-1 MAJOR for at least
+12 months. Libraries SHOULD aim for the same window where practical.
+
+## Schema namespace versioning vs. spec versioning
+
+These are independent. `phip:mechanical@1.0` is a separate version
+track from PhIP-Core@0.1.0-draft. Adding `phip:electrical@1.0` does
+not bump the spec; tightening the core lifecycle table does.
+
+The `/.well-known/phip/meta` document advertises both:
+- `protocol_version` for the spec
+- `schema_namespaces` listing supported namespaces with optional
+  `@MAJOR.MINOR` suffixes
+
+## Reference implementation
+
+The reference resolver in `reference/` tracks the **current spec
+version** at HEAD. It does not maintain backward-compatibility
+shims. When the spec adds a new feature, the reference adds support
+in the same PR. When the spec breaks something, the reference breaks
+in the same PR.
+
+The reference is a spec-validation tool, not a deployable
+production server. Production servers (`phip-server` and any
+language-specific equivalents) are responsible for their own
+backward-compatibility windows.
+
+## Conformance suite versioning
+
+The HTTP conformance suite (`tests/conformance/`) and the
+language-agnostic vectors (`tests/vectors/`) version with the spec
+MAJOR. A library that claims to implement PhIP v0.1 MUST pass the
+v0.1 conformance suite, not the v0.2 suite (they may differ in test
+counts as new operations are added).
+
+## Pre-1.0 caveats
+
+While the spec is at `0.x`, MINOR bumps MAY introduce breaking
+changes. The protocol is explicitly not stable until v1.0. Libraries
+SHOULD warn consumers about this in their READMEs.
+
+When the spec hits 1.0, this document is updated to remove this
+caveat and the strict-SemVer rules above take effect for all
+versioned components.

--- a/schemas/authority-transfer-payload.json
+++ b/schemas/authority-transfer-payload.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/mfgs-us/phip/schemas/authority-transfer-payload.json",
+  "version": "1.0",
+  "title": "PhIP authority_transfer Event Payload",
+  "description": "Schema for the payload field of an authority_transfer event (Section 4.6.2). The event itself follows the standard event shape (event_id, phip_id, type, timestamp, actor, previous_hash, payload, signature) and MUST be signed by the source authority's root key. This schema validates only the payload object.",
+
+  "type": "object",
+  "required": ["namespaces", "successor_authority", "successor_root_key", "effective_from"],
+  "additionalProperties": false,
+  "properties": {
+    "namespaces": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "minItems": 1,
+      "description": "Array of namespace names being transferred. MAY be ['*'] to transfer all namespaces under the source authority."
+    },
+    "successor_authority": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9.-]+$",
+      "description": "Authority name (DNS label) the namespaces transfer to."
+    },
+    "successor_root_key": {
+      "type": "string",
+      "pattern": "^phip://[A-Za-z0-9.-]+/[A-Za-z0-9._~%-]+(?:/[A-Za-z0-9._~%-]+)+$",
+      "description": "PhIP URI of the successor's root key resource. Verifiers MUST resolve and validate this key before accepting subsequent events under the transferred namespaces."
+    },
+    "effective_from": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 timestamp at which the transfer takes effect. Events appended after this timestamp under the transferred namespaces SHOULD be hosted by the successor."
+    },
+    "rationale": {
+      "type": "string",
+      "description": "Optional human-readable explanation (e.g. 'Acme acquired by NewCo (2026-12-15). Sole transfer of all asset records.')."
+    }
+  }
+}

--- a/schemas/bundle-manifest.json
+++ b/schemas/bundle-manifest.json
@@ -1,0 +1,85 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/mfgs-us/phip/schemas/bundle-manifest.json",
+  "version": "1.0",
+  "title": "PhIP Bundle Manifest",
+  "description": "Schema for the manifest.json file inside a PhIP bundle (Section 4.3.4). The bundle is a signed archive of objects + their histories + key resources, used for offline distribution, mirror snapshots, and air-gapped imports. The manifest is the integrity anchor: signed by the producer's actor key, listing every object in the bundle with its expected history_head.",
+
+  "type": "object",
+  "required": ["bundle_version", "created_at", "created_by", "authority", "objects", "signature"],
+  "additionalProperties": false,
+  "properties": {
+    "bundle_version": {
+      "type": "string",
+      "const": "1.0",
+      "description": "Bundle format version. MUST be '1.0' for this revision of the spec."
+    },
+    "created_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 timestamp the bundle was assembled."
+    },
+    "created_by": {
+      "$ref": "#/$defs/phipUri",
+      "description": "PhIP URI of the actor producing the bundle. The signature is computed by this actor's key."
+    },
+    "authority": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9.-]+$",
+      "description": "Source authority name whose records are being bundled."
+    },
+    "objects": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["phip_id", "history_head"],
+        "additionalProperties": false,
+        "properties": {
+          "phip_id": {
+            "$ref": "#/$defs/phipUri",
+            "description": "Object identifier."
+          },
+          "history_head": {
+            "type": "string",
+            "pattern": "^sha256:[0-9a-f]{64}$",
+            "description": "SHA-256 hash of the latest event in this object's history at bundle-creation time."
+          }
+        }
+      },
+      "minItems": 1,
+      "description": "Per-object integrity manifest. Consumers verify each object's full chain reaches this head."
+    },
+    "snapshot_of": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Optional ISO 8601 timestamp this bundle represents the source authority's state as of. For continuously-updated mirror snapshots; absent for ad-hoc exports."
+    },
+    "signature": {
+      "type": "object",
+      "required": ["algorithm", "key_id", "value"],
+      "additionalProperties": false,
+      "properties": {
+        "algorithm": {
+          "type": "string",
+          "const": "Ed25519"
+        },
+        "key_id": {
+          "$ref": "#/$defs/phipUri",
+          "description": "Key actor URI whose phip:keys material verifies this signature. SHOULD match created_by or be derivable from it."
+        },
+        "value": {
+          "type": "string",
+          "pattern": "^(base64url:)?[A-Za-z0-9_-]+$",
+          "description": "Base64url-encoded 64-byte Ed25519 signature over the JCS canonicalization of the manifest with the signature field removed."
+        }
+      }
+    }
+  },
+
+  "$defs": {
+    "phipUri": {
+      "type": "string",
+      "pattern": "^phip://[A-Za-z0-9.-]+/[A-Za-z0-9._~%-]+(?:/[A-Za-z0-9._~%-]+)+$"
+    }
+  }
+}

--- a/schemas/bundle-manifest.json
+++ b/schemas/bundle-manifest.json
@@ -69,8 +69,8 @@
         },
         "value": {
           "type": "string",
-          "pattern": "^(base64url:)?[A-Za-z0-9_-]+$",
-          "description": "Base64url-encoded 64-byte Ed25519 signature over the JCS canonicalization of the manifest with the signature field removed."
+          "pattern": "^(base64url:)?[A-Za-z0-9_-]{86}$",
+          "description": "Base64url-encoded 64-byte Ed25519 signature (exactly 86 base64url characters, no padding) over the JCS canonicalization of the manifest with the signature field removed."
         }
       }
     }

--- a/schemas/capability-token.json
+++ b/schemas/capability-token.json
@@ -17,12 +17,12 @@
     "expires",
     "signature"
   ],
-  "additionalProperties": false,
+  "additionalProperties": true,
   "properties": {
     "phip_capability": {
       "type": "string",
       "const": "1.0",
-      "description": "Token format version. MUST be '1.0' for this revision of the spec."
+      "description": "Token format version. MUST be '1.0' for this revision of the spec. Future spec MINOR bumps may add optional fields without changing this value; v1.0 validators MUST tolerate unknown fields (additionalProperties: true)."
     },
     "token_id": {
       "type": "string",
@@ -31,7 +31,7 @@
     },
     "granted_by": {
       "$ref": "#/$defs/phipUri",
-      "description": "PhIP URI of the actor who issued the token. MUST resolve to an `actor` object in the granting authority's namespace."
+      "description": "PhIP URI of the actor who issued the token. MUST resolve to an `actor` object in the granting authority's namespace. Per §11.2, key resources are themselves actors, so a key URI like `phip://acme.example/keys/ops-2026` is a valid grantor."
     },
     "granted_to": {
       "$ref": "#/$defs/phipUri",
@@ -91,8 +91,8 @@
         },
         "value": {
           "type": "string",
-          "pattern": "^(base64url:)?[A-Za-z0-9_-]+$",
-          "description": "Base64url-encoded 64-byte Ed25519 signature. The optional `base64url:` prefix is permitted for compatibility with spec examples."
+          "pattern": "^(base64url:)?[A-Za-z0-9_-]{86}$",
+          "description": "Base64url-encoded 64-byte Ed25519 signature (exactly 86 base64url characters, no padding). The optional `base64url:` prefix is permitted for compatibility with spec examples."
         }
       }
     }

--- a/schemas/capability-token.json
+++ b/schemas/capability-token.json
@@ -1,0 +1,100 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/mfgs-us/phip/schemas/capability-token.json",
+  "version": "1.0",
+  "title": "PhIP Capability Token",
+  "description": "Schema for the PhIP capability token format defined in Section 11.3. Tokens are JSON objects, base64url-encoded for transport in the `Authorization: PhIP-Capability <token>` header. Cryptographic verification (signature, key resolution, scope/filter/expiry checks) is enforced by resolvers per Section 11.3.4 and is outside the scope of this schema.",
+
+  "type": "object",
+  "required": [
+    "phip_capability",
+    "token_id",
+    "granted_by",
+    "granted_to",
+    "scope",
+    "object_filter",
+    "not_before",
+    "expires",
+    "signature"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "phip_capability": {
+      "type": "string",
+      "const": "1.0",
+      "description": "Token format version. MUST be '1.0' for this revision of the spec."
+    },
+    "token_id": {
+      "type": "string",
+      "description": "Unique identifier for this token, typically a UUID. Used for revocation lists and replay detection.",
+      "minLength": 1
+    },
+    "granted_by": {
+      "$ref": "#/$defs/phipUri",
+      "description": "PhIP URI of the actor who issued the token. MUST resolve to an `actor` object in the granting authority's namespace."
+    },
+    "granted_to": {
+      "$ref": "#/$defs/phipUri",
+      "description": "PhIP URI of the actor authorized to use this token. The resolver compares against the requesting actor (when externally authenticated)."
+    },
+    "scope": {
+      "type": "string",
+      "enum": [
+        "push_events",
+        "push_state",
+        "push_measurements",
+        "push_relations",
+        "read_state",
+        "read_history",
+        "read_query"
+      ],
+      "description": "Permission level granted by this token. A single token has exactly one scope; combining scopes requires issuing multiple tokens. See Section 11.3.2."
+    },
+    "object_filter": {
+      "type": "string",
+      "description": "Glob pattern matching target `phip_id`s. Uses `*` for wildcard. Tokens that match no object are useless; tokens that match `phip://*` grant authority-wide access (rare in practice).",
+      "minLength": 1
+    },
+    "not_before": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 timestamp before which the token is invalid."
+    },
+    "expires": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 timestamp after which the token is invalid. Resolvers SHOULD reject tokens with expiry windows greater than 90 days (Section 11.3.5)."
+    },
+    "signature": {
+      "$ref": "#/$defs/signature",
+      "description": "Ed25519 signature over the JCS canonicalization of the token with the `signature` field stripped, computed by the granting authority."
+    }
+  },
+
+  "$defs": {
+    "phipUri": {
+      "type": "string",
+      "pattern": "^phip://[A-Za-z0-9.-]+/[A-Za-z0-9._~%-]+(?:/[A-Za-z0-9._~%-]+)+$"
+    },
+    "signature": {
+      "type": "object",
+      "required": ["algorithm", "key_id", "value"],
+      "additionalProperties": false,
+      "properties": {
+        "algorithm": {
+          "type": "string",
+          "const": "Ed25519"
+        },
+        "key_id": {
+          "$ref": "#/$defs/phipUri",
+          "description": "PhIP URI of the key actor that signed this token. The resolver fetches this actor's `phip:keys` material to verify the signature."
+        },
+        "value": {
+          "type": "string",
+          "pattern": "^(base64url:)?[A-Za-z0-9_-]+$",
+          "description": "Base64url-encoded 64-byte Ed25519 signature. The optional `base64url:` prefix is permitted for compatibility with spec examples."
+        }
+      }
+    }
+  }
+}

--- a/schemas/meta.json
+++ b/schemas/meta.json
@@ -1,0 +1,162 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/mfgs-us/phip/schemas/meta.json",
+  "version": "1.0",
+  "title": "PhIP Resolver Metadata Document",
+  "description": "Schema for the resolver metadata document at /.well-known/phip/meta defined in Section 12.7. This document describes the resolver's protocol version, supported operations, conformance class, and federation state (root key, delegations, successor, mirror URLs).",
+
+  "type": "object",
+  "required": ["protocol_version", "authority", "namespaces"],
+  "properties": {
+    "protocol_version": {
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+(\\.[0-9]+)?(-[A-Za-z0-9.-]+)?$",
+      "description": "Spec version this resolver targets (e.g. '0.1.0-draft')."
+    },
+    "authority": {
+      "type": "string",
+      "pattern": "^[A-Za-z0-9.-]+$",
+      "description": "DNS-like authority name this resolver serves."
+    },
+    "namespaces": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Namespaces this resolver will accept CREATEs into."
+    },
+    "schema_namespaces": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "description": "Schema namespace identifier, optionally with @-prefixed semver (e.g. 'phip:mechanical@1.2'). Bare names mean 'latest supported'."
+      }
+    },
+    "supported_operations": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": ["create", "get", "push", "query", "history", "batch_create", "batch_push"]
+      }
+    },
+    "query_capabilities": {
+      "type": "object",
+      "description": "Optional map describing supported filter operators, glob syntax, sort orders. Schema is open-ended.",
+      "additionalProperties": true
+    },
+    "root_key": {
+      "$ref": "#/$defs/phipUri",
+      "description": "PhIP URI of this authority's root key (Section 4.6.1). Used as the trust anchor for authority-transfer verification."
+    },
+    "mirror_urls": {
+      "type": "array",
+      "items": { "type": "string", "format": "uri" },
+      "description": "URLs of read-only mirrors hosting frozen snapshots of this authority's records (Section 4.6.5)."
+    },
+    "successor": {
+      "type": "object",
+      "required": ["authority", "namespaces", "transfer_event_id"],
+      "additionalProperties": true,
+      "description": "Present iff this authority has been transferred (Section 4.6.2). Clients SHOULD redirect subsequent requests to the successor.",
+      "properties": {
+        "authority": {
+          "type": "string",
+          "pattern": "^[A-Za-z0-9.-]+$",
+          "description": "DNS-like authority name of the successor."
+        },
+        "namespaces": {
+          "type": "array",
+          "items": { "type": "string" },
+          "minItems": 1,
+          "description": "Namespaces transferred to the successor. Use ['*'] to transfer all."
+        },
+        "transfer_event_id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Event ID of the originating authority_transfer event. Required for the PhIP-Transfer-Event header."
+        },
+        "effective_from": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "delegations": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/delegation" },
+      "description": "Active sub-namespace delegations (Section 4.5.1)."
+    },
+    "conformance_class": {
+      "type": "string",
+      "enum": ["full", "read-only", "mirror", "client-only"],
+      "description": "Conformance class advertised by this resolver. Absence implies 'full' for v0.1 compatibility."
+    },
+    "batch_max_events": {
+      "type": "integer",
+      "exclusiveMinimum": 0,
+      "description": "Advisory maximum events per batch CREATE/PUSH. Resolvers MAY enforce a lower limit than the spec's 1000 cap."
+    },
+    "mtls_required": {
+      "type": "boolean",
+      "description": "If true, clients MUST present a TLS client certificate (Section 12.8.1)."
+    },
+    "mtls_ca_bundle_url": {
+      "type": "string",
+      "format": "uri",
+      "description": "URL where the resolver publishes its CA bundle for client cert issuance."
+    }
+  },
+  "additionalProperties": true,
+
+  "$defs": {
+    "phipUri": {
+      "type": "string",
+      "pattern": "^phip://[A-Za-z0-9.-]+/[A-Za-z0-9._~%-]+(?:/[A-Za-z0-9._~%-]+)+$"
+    },
+    "delegation": {
+      "type": "object",
+      "required": ["namespace", "delegate_authority", "delegate_root_key", "scope", "effective_from"],
+      "additionalProperties": true,
+      "properties": {
+        "namespace": {
+          "type": "string",
+          "description": "Namespace being delegated. '*' delegates the entire authority."
+        },
+        "prefix": {
+          "type": "string",
+          "description": "Local-id prefix the delegation applies to. If omitted, applies to the entire namespace."
+        },
+        "delegate_authority": {
+          "type": "string",
+          "pattern": "^[A-Za-z0-9.-]+$"
+        },
+        "delegate_root_key": {
+          "$ref": "#/$defs/phipUri"
+        },
+        "scope": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": ["create", "push", "get", "history", "query"]
+          },
+          "minItems": 1
+        },
+        "effective_from": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "expires": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "revocable": {
+          "type": "boolean",
+          "default": true
+        },
+        "max_subdelegation": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Maximum further delegation depth permitted under this entry. 0 = no sub-delegation. Absent = unlimited."
+        }
+      }
+    }
+  }
+}

--- a/spec/CHANGELOG.md
+++ b/spec/CHANGELOG.md
@@ -5,6 +5,44 @@ All notable changes to the PhIP specification will be documented in this file.
 ## [0.1.0-draft] — 2026-04-09
 
 ### Added
+- Library prerequisites: four new JSON Schemas (`schemas/capability-token.json`,
+  `schemas/meta.json`, `schemas/authority-transfer-payload.json`,
+  `schemas/bundle-manifest.json`) so client libs validate structurally
+  without each one reinventing validation; pointers added from §11.3.1,
+  §12.7, §4.6.2, and §4.3.4 to the corresponding schemas.
+- Capability token test vectors (`tests/vectors/token/`) covering 9
+  cases: valid push and read tokens, expired, not-yet-valid,
+  object_filter mismatch, forged signature, post-signing tamper,
+  read-history-covers-read-state, and foreign-signer.
+- Bundle test vectors (`tests/vectors/bundle/`) covering 3 cases:
+  one-object snapshot, multi-object snapshot, and tampered-event
+  rejection. Self-check verifies manifest signatures, full chain
+  walks, and embedded key actor presence.
+- New §11.6 Caller Authentication: defines mTLS (§11.6.1) and signed
+  HTTP requests per RFC 9421 (§11.6.2) as the two interoperable
+  mechanisms for binding a capability token to its actual requester.
+  Closes the bearer-token gap that made §11.5.2 step-7 tautological.
+- New §12.2.2 Cursor Stability: cursors MUST survive resolver restart
+  and replica swap, MUST be portable across authority transfers,
+  cursor-expired surfaces as `INVALID_QUERY` with `details.reason`.
+- New §12.3.2 General Retry Guidance: per-status retry semantics,
+  exponential-backoff defaults, idempotency-on-`event_id` guarantee
+  for safe POST retries.
+- `VERSIONING.md`: spec MAJOR/MINOR/PATCH rules, library-tracks-spec
+  pinning, schema-version independence, compatibility window.
+- `CONTRIBUTING.md`: PR checklist, scope rules, reference-vs-server
+  boundary, spec change process.
+- `IMPLEMENTATIONS.md`: registry of known PhIP implementations with
+  conformance status.
+- `@phip/conformance` package: `tests/conformance/` is now a
+  publishable npm package with a `phip-conformance` bin. Operators
+  install with `npm install -g @phip/conformance` and probe any
+  resolver from one command. Self-contained (test keypair embedded;
+  no dependency on the wider repo).
+- Conformance §20 federation mechanics (opt-in): when the resolver's
+  `/meta` advertises `delegations` or `successor`, the suite probes
+  the redirect machinery (`Location`, `PhIP-Delegation`,
+  `PhIP-Transfer-Event` headers).
 - Interop prerequisites for multi-language client libraries (`phip-js`, 
   `phip-py`, etc.): language-agnostic test vectors in `tests/vectors/` 
   covering JCS canonicalization, SHA-256 event hashing, Ed25519 signing 

--- a/spec/phip-core.md
+++ b/spec/phip-core.md
@@ -309,7 +309,8 @@ clients SHOULD follow these constraints to maximize reuse:
 **Signed bundle distribution.** When a connected reference machine 
 needs to distribute records to a wholly disconnected site, the 
 authoritative wire format is a **PhIP bundle**: a signed archive 
-of one or more objects' states and histories. Bundle format:
+of one or more objects' states and histories. The manifest shape is
+defined by `schemas/bundle-manifest.json`. Bundle format:
 
 ```
 phip-bundle.tar
@@ -619,6 +620,9 @@ itself. Its history records key rotations, namespace registrations,
 and any transfer events. The authority record's `created` event MUST 
 be signed by the root key (a self-signed bootstrap, per Section 
 11.2.4 conventions adapted for the authority record).
+
+The payload shape is defined by `schemas/authority-transfer-payload.json`
+alongside the prose below.
 
 An `authority_transfer` event payload:
 
@@ -1864,6 +1868,9 @@ a capability token issued by the namespace authority.
 
 #### 11.3.1 Token Format
 
+The token shape is defined by `schemas/capability-token.json` 
+(machine-readable JSON Schema) alongside the prose below.
+
 ```json
 {
   "phip_capability": "1.0",
@@ -2209,6 +2216,136 @@ provenance claims that are intended to be verifiable by any party.
 Authorities that hold commercially sensitive data MUST attach 
 `phip:access` explicitly — silence is consent.
 
+### 11.6 Caller Authentication
+
+Capability tokens (Section 11.3) declare *what* an actor is permitted 
+to do. To enforce them under a `policy: capability` access mode 
+(Section 11.5.1), the resolver also needs to know *who is making the 
+request* — independently of the bearer-style token they present. 
+Without a separate caller identity, the §11.5.2 step-7 check 
+(`granted_to` matches the requesting actor) is structurally present 
+but tautological.
+
+PhIP defines two interoperable mechanisms for caller authentication. 
+Resolvers that enforce `policy: capability` MUST implement at least 
+one. Resolvers MAY accept both and let operators choose.
+
+#### 11.6.1 Mutual TLS
+
+The simplest mechanism: the resolver requires the client to present 
+an X.509 certificate during the TLS handshake. The certificate is 
+signed by a CA the resolver trusts. The certificate's identity field 
+maps to a PhIP actor URI as follows:
+
+1. The resolver looks for a Subject Alternative Name (SAN) of type 
+   `URI` whose value is a PhIP URI (`phip://...`). If present and 
+   valid, that URI is the caller's actor.
+2. Otherwise, the resolver maps the certificate's Subject Common Name 
+   (CN) to a PhIP actor URI via an operator-configured policy 
+   (typically `cn → phip://{authority}/actors/{cn}`). This fallback 
+   exists for compatibility with PKI deployments that don't issue 
+   PhIP-aware certificates.
+
+The resolver MUST then perform the §11.5.2 step-7 check: the 
+identified actor MUST equal the token's `granted_to`.
+
+mTLS is operationally heavy (cert provisioning, rotation, revocation 
+via CRL/OCSP) but battle-tested. It is the recommended mechanism for 
+production deployments that already operate a PKI.
+
+#### 11.6.2 Signed Requests
+
+For deployments that prefer not to operate mTLS (browser-originated 
+calls, edge runtimes, mobile clients), the resolver MAY accept signed 
+HTTP requests per RFC 9421 (HTTP Message Signatures). The caller 
+signs the request with their PhIP actor key; the resolver verifies 
+the signature against that actor's `phip:keys` material.
+
+A PhIP signed request MUST satisfy the following profile:
+
+1. **Algorithm.** `Ed25519` (RFC 9421 §3.3.6).
+2. **Covered components.** The signature MUST cover, in this order:
+   - `@method`
+   - `@target-uri`
+   - `content-digest` (RFC 9530 SHA-256 digest of the request body, 
+     omitted only when the body is empty)
+   - `phip-actor` (the new request header defined below)
+   - `created` (signature parameter — the Unix timestamp at which the 
+     signature was created)
+3. **Header: `PhIP-Actor`.** A new request header carrying the PhIP 
+   URI of the signing actor. The `keyid` parameter on the signature 
+   input MUST be a PhIP URI identifying the signing key actor 
+   (`keyid` and `PhIP-Actor` MAY be different — `keyid` is the key 
+   actor, `PhIP-Actor` is the requesting actor; the relationship is 
+   established by the requesting actor's `phip:keys` attribute or by 
+   the requesting actor delegating signing to the key actor).
+4. **Signature freshness.** The `created` parameter MUST be within 
+   ±300 seconds of the resolver's current time. Older requests MUST 
+   be rejected to mitigate replay.
+5. **Replay window.** Resolvers SHOULD maintain a short-lived cache 
+   (≥ 600 seconds) of seen signature values keyed by `keyid` and 
+   `created` to reject exact replays.
+
+Example (RFC 9421 illustrative format):
+
+```
+POST /.well-known/phip/push/parts/widget-001 HTTP/1.1
+Host: acme.example
+Content-Type: application/json
+Content-Digest: sha-256=:X48E9qOokqqrvdts8nOJRJN3OWDUoyWxBf7kbu9DBPE=:
+PhIP-Actor: phip://acme.example/actors/operator-jane
+Signature-Input: phip=("@method" "@target-uri" "content-digest" "phip-actor");\
+                 keyid="phip://acme.example/keys/jane-laptop-2026";\
+                 created=1735689600
+Signature: phip=:wqcAqbmYJ2ji2glfAMaRy4gruYYnx2nEFN2HN6jrnDnQCK1u02Gb04v9EDgwUPiu4A0w6vuQv5lIp5WPpBKSrw==:
+```
+
+The resolver verifies by:
+1. Resolving `keyid` to a key actor (locally or via federation).
+2. Confirming the key actor is `active` and the request's `created` 
+   timestamp falls within its validity window.
+3. Reconstructing the signature base per RFC 9421 from the listed 
+   covered components.
+4. Verifying the Ed25519 signature against the resolved key.
+5. Mapping `PhIP-Actor` to the requesting-actor identity for the 
+   §11.5.2 step-7 check. The resolver MUST verify that the signing 
+   key (`keyid`) is authorized to act for `PhIP-Actor` — typically 
+   by checking that `PhIP-Actor`'s `phip:keys` attribute references 
+   the same key, or that the key actor's history records a 
+   `delegated_signing_for` relation pointing at `PhIP-Actor` (an 
+   informal pattern; v0.1 leaves the binding mechanism to operator 
+   policy).
+
+If any step fails, the resolver MUST reject with `INVALID_SIGNATURE` 
+(401) for cryptographic failures or `MISSING_CAPABILITY` (403) for 
+absent signature headers on a `policy: capability` object.
+
+#### 11.6.3 Header Co-existence
+
+Both mechanisms MAY appear on the same request:
+
+- mTLS provides transport-level identity (the connection is from 
+  this client cert).
+- `PhIP-Capability` provides the authorization grant (this client is 
+  permitted to do X).
+- `Signature` (RFC 9421) provides application-level identity — 
+  optional when mTLS is used, required when mTLS is not.
+
+When both mTLS and signed-request are presented, the resolver MUST 
+verify that the identities agree. Disagreement MUST be treated as 
+`INVALID_SIGNATURE` (401).
+
+#### 11.6.4 Bearer Tokens Are Insufficient
+
+A capability token alone is a bearer secret: anyone who steals the 
+token impersonates the grantee. Section 11.6 exists because PhIP's 
+trust model requires the resolver to bind the token to the actual 
+requesting party, not just accept the token at face value. 
+Resolvers serving `policy: capability` objects MUST NOT skip caller 
+authentication on the grounds that the token "looks valid" — the 
+bearer-only path is reserved for `policy: authenticated`, where any 
+holder of any read scope is admitted.
+
 ---
 
 ## 12. Protocol Operations
@@ -2338,6 +2475,37 @@ This is not a separate protocol operation — it is a sub-resource of GET,
 providing paginated access to the same history that the object model 
 references.
 
+#### 12.2.2 Cursor Stability
+
+Cursors are opaque from the client's perspective: the resolver decides 
+the encoding. Stability guarantees:
+
+- **Within an object's lifetime**, a cursor returned by the resolver 
+  MUST remain valid as long as the object exists. New events appended 
+  after the cursor was issued are returned by subsequent paginated 
+  requests; previously-returned events are NOT re-returned.
+- **Across resolver restarts**, cursors MUST remain valid. Cursors 
+  encode position in the chain (e.g., a hash, an index, a timestamp); 
+  they MUST NOT depend on in-memory state lost on restart.
+- **Across resolver replicas**, cursors MUST be portable. A cursor 
+  issued by one replica of a resolver MUST be valid against any other 
+  replica serving the same authority. This rules out memory-only 
+  sequence counters as cursor encodings.
+- **Across authority transfers** (§4.6), cursors MUST remain valid 
+  against the successor for objects whose namespace was transferred, 
+  provided the successor serves the full pre-transfer history.
+
+A resolver that cannot honor a cursor (e.g., because it was issued 
+against a snapshot the resolver no longer holds) MUST return 
+`INVALID_QUERY` (422) with a `details.reason` of `cursor_expired` or 
+`cursor_unrecognized`. Clients receiving this MUST re-request from 
+the beginning rather than retrying with the same cursor.
+
+Resolvers SHOULD NOT encode authority-private state in cursors. A 
+cursor of the form `sha256:<hash-of-last-returned-event>` is a 
+recommended pattern: stable across restart, portable across replicas, 
+and verifiable client-side.
+
 ### 12.3 PUSH
 
 Append an event to an object's history.
@@ -2393,6 +2561,52 @@ pushes. The linear hash chain is the authoritative ordering.
 Resolvers SHOULD process pushes to the same object serially to minimize 
 conflict frequency. The spec does not define a maximum retry count or 
 backoff strategy — these are client implementation concerns.
+
+#### 12.3.2 General Retry Guidance
+
+Beyond `CHAIN_CONFLICT`, clients face transient transport-layer 
+failures (network errors, 5xx responses, connection resets). To 
+prevent every PhIP client library from inventing its own retry 
+policy, the spec gives the following normative guidance:
+
+**By HTTP status:**
+
+| Status range | Retry semantics |
+|---|---|
+| `2xx` | Don't retry — operation succeeded |
+| `3xx` | Don't retry as PhIP — follow the redirect per §4.3.3 / §4.5.2 / §4.6.4 |
+| `400` | Don't retry — client error; retry will fail identically |
+| `401`, `403` | Don't retry without remediation — auth/cap error; the client must obtain a valid token or actor identity first |
+| `404` | Don't retry — object doesn't exist |
+| `408`, `429` | Retry — honor `Retry-After` if present, else exponential backoff |
+| `409` | Retry only if the underlying error code is recoverable: `CHAIN_CONFLICT` per §12.3.1; `OBJECT_EXISTS` and `DUPLICATE_EVENT` are NOT recoverable |
+| `4xx` (other) | Don't retry — client error |
+| `5xx` | Retry with exponential backoff |
+| Network error (no response) | Retry with exponential backoff for idempotent methods (GET, HEAD); for POST, retry only when the resolver explicitly advertises idempotency via response headers, or when the client knows the request was idempotent (e.g., `event_id` deduplication on PUSH) |
+
+**Backoff:** Clients SHOULD use exponential backoff with jitter. A 
+recommended default: base 1 second, multiplier 2.0, jitter ±50%, 
+maximum 30 seconds, maximum 5 attempts. Resolvers MAY advertise 
+preferred backoff parameters via `/meta` in a future revision.
+
+**Idempotency on POST.** PhIP events carry a unique `event_id`. A 
+resolver receiving a duplicate `event_id` MUST return 
+`DUPLICATE_EVENT` (409) without applying it twice. This makes PUSH 
+safe to retry on transport failures: if the original request 
+succeeded but the response was lost, the retry sees `DUPLICATE_EVENT` 
+and the client knows the operation completed. Clients MAY treat 
+`DUPLICATE_EVENT` as success when retrying after a transport failure.
+
+CREATE is similarly idempotent on `event_id` (the genesis event's 
+id is unique per object), but the natural error on retry is 
+`OBJECT_EXISTS` rather than `DUPLICATE_EVENT` because the resolver 
+sees the prior CREATE succeeded.
+
+**Don't retry forever.** Clients SHOULD enforce a maximum total wall 
+time per logical operation (recommended: 30 seconds for interactive 
+calls, 5 minutes for batch ingestion). Retries that exceed this 
+budget MUST surface the underlying error to the caller rather than 
+masking it as a hang.
 
 ### 12.4 QUERY
 
@@ -2677,6 +2891,9 @@ Error responses MUST NOT be signed. They are informational, not
 historical records. HTTPS is the integrity mechanism for error responses.
 
 ### 12.7 Metadata Document
+
+The document shape is defined by `schemas/meta.json` (machine-readable
+JSON Schema) alongside the prose below.
 
 An authority MAY publish a metadata document describing its resolver's
 capabilities:

--- a/spec/phip-core.md
+++ b/spec/phip-core.md
@@ -334,6 +334,7 @@ The `manifest.json` MUST contain:
 | `created_by` | MUST | PhIP URI of the actor producing the bundle |
 | `authority` | MUST | Source authority name |
 | `objects` | MUST | Array of bundled `phip_id`s with `history_head` per object — bundle-level integrity manifest |
+| `snapshot_of` | MAY | ISO 8601 timestamp this bundle represents the source authority's state as of. Used by mirror snapshots (§4.6.5) to declare currency; ad-hoc exports omit it |
 | `signature` | MUST | Ed25519 signature over the JCS canonicalization of the manifest minus this field, signed by `created_by` |
 
 A consumer importing a bundle MUST:
@@ -2264,26 +2265,32 @@ the signature against that actor's `phip:keys` material.
 A PhIP signed request MUST satisfy the following profile:
 
 1. **Algorithm.** `Ed25519` (RFC 9421 §3.3.6).
-2. **Covered components.** The signature MUST cover, in this order:
-   - `@method`
-   - `@target-uri`
-   - `content-digest` (RFC 9530 SHA-256 digest of the request body, 
-     omitted only when the body is empty)
-   - `phip-actor` (the new request header defined below)
-   - `created` (signature parameter — the Unix timestamp at which the 
-     signature was created)
-3. **Header: `PhIP-Actor`.** A new request header carrying the PhIP 
-   URI of the signing actor. The `keyid` parameter on the signature 
-   input MUST be a PhIP URI identifying the signing key actor 
-   (`keyid` and `PhIP-Actor` MAY be different — `keyid` is the key 
-   actor, `PhIP-Actor` is the requesting actor; the relationship is 
-   established by the requesting actor's `phip:keys` attribute or by 
-   the requesting actor delegating signing to the key actor).
-4. **Signature freshness.** The `created` parameter MUST be within 
-   ±300 seconds of the resolver's current time. Older requests MUST 
-   be rejected to mitigate replay.
-5. **Replay window.** Resolvers SHOULD maintain a short-lived cache 
-   (≥ 600 seconds) of seen signature values keyed by `keyid` and 
+2. **Covered components.** Per RFC 9421 §2, "covered components" are
+   the named items listed in the `Signature-Input` parentheses. The
+   signature MUST cover the following four components, in this order:
+   - `@method` (RFC 9421 derived component)
+   - `@target-uri` (derived component)
+   - `content-digest` (header, RFC 9530 SHA-256 digest of the request
+     body; the header MAY be omitted only when the body is empty, in
+     which case `content-digest` is also omitted from the covered set)
+   - `phip-actor` (header — defined in 3 below)
+3. **Required signature parameters.** The `Signature-Input` value
+   MUST also carry these RFC 9421 §2.3 parameters:
+   - `keyid` — a PhIP URI identifying the signing key actor
+   - `created` — the Unix timestamp at which the signature was
+     produced; used for the freshness check in 5 below
+   The `alg` parameter is OPTIONAL; when present it MUST be `"ed25519"`.
+4. **Header: `PhIP-Actor`.** A new request header carrying the PhIP
+   URI of the signing actor. `keyid` and `PhIP-Actor` MAY be different
+   — `keyid` is the key actor, `PhIP-Actor` is the requesting actor;
+   the relationship is established by the requesting actor's
+   `phip:keys` attribute or by the requesting actor delegating signing
+   to the key actor.
+5. **Signature freshness.** The `created` parameter MUST be within
+   ±300 seconds of the resolver's current time. Older or future-dated
+   requests MUST be rejected to mitigate replay.
+6. **Replay window.** Resolvers SHOULD maintain a short-lived cache
+   (≥ 600 seconds) of seen signature values keyed by `keyid` and
    `created` to reject exact replays.
 
 Example (RFC 9421 illustrative format):
@@ -2559,8 +2566,10 @@ The resolver MUST NOT reorder, merge, or silently resolve concurrent
 pushes. The linear hash chain is the authoritative ordering.
 
 Resolvers SHOULD process pushes to the same object serially to minimize 
-conflict frequency. The spec does not define a maximum retry count or 
-backoff strategy — these are client implementation concerns.
+conflict frequency. Maximum retry count and backoff strategy for 
+`CHAIN_CONFLICT` recovery are client concerns; see §12.3.2 for general 
+guidance that applies to retry behavior across all status codes, 
+including the recommended exponential-backoff defaults.
 
 #### 12.3.2 General Retry Guidance
 
@@ -2884,7 +2893,7 @@ structure is not normative.
 | `INVALID_TRACK` | 422 | State is not valid for this object type's lifecycle track |
 | `INVALID_RELATION` | 422 | Relation type constraint violated (e.g., `located_at` target is not a `location` or `vehicle`) |
 | `DANGLING_RELATION` | 422 | A same-authority relation references a `phip_id` that does not exist (Section 7.4) |
-| `INVALID_QUERY` | 422 | Query predicate is malformed or uses unsupported features |
+| `INVALID_QUERY` | 422 | Query predicate is malformed or uses unsupported features. For history pagination, `details.reason` MAY be `cursor_expired` (resolver no longer holds the cursor's anchor point) or `cursor_unrecognized` (cursor not issued by this resolver). See §12.2.2 |
 | `OPERATION_NOT_SUPPORTED` | 405 | Resolver does not implement the requested operation under its declared conformance class (Section 13). Examples: writes against a Read-Only or Mirror resolver, QUERY against a Mirror resolver |
 
 Error responses MUST NOT be signed. They are informational, not 
@@ -2911,13 +2920,16 @@ fields:
 | `authority` | string | MUST | The authority name this resolver serves |
 | `namespaces` | array of strings | MUST | Namespaces this resolver will accept CREATEs into |
 | `schema_namespaces` | array of strings | SHOULD | Attribute namespaces whose schemas this resolver validates (e.g. `phip:mechanical`, `phip:software`) |
-| `supported_operations` | array of strings | SHOULD | Subset of `["create", "get", "push", "query", "history"]` |
+| `supported_operations` | array of strings | SHOULD | Subset of `["create", "get", "push", "query", "history", "batch_create", "batch_push"]` |
 | `query_capabilities` | object | MAY | Optional map describing supported filter operators, glob syntax, sort orders |
 | `root_key` | string | SHOULD | PhIP URI of this authority's root key (Section 4.6.1). Clients use this to anchor trust for transfer verification |
 | `mirror_urls` | array of strings | MAY | URLs of read-only mirrors hosting frozen snapshots of this authority's records. See Section 4.6.5 |
 | `successor` | object | MAY | Present iff this authority has been transferred. Object: `{ "authority": "newco.example", "transfer_event_id": "...", "effective_from": "..." }`. Clients SHOULD redirect subsequent requests to the successor |
 | `delegations` | array of objects | MAY | Active sub-namespace delegations. See Section 4.5.1 for entry shape |
 | `conformance_class` | string | SHOULD | One of `full`, `read-only`, `mirror`, `client-only` (Section 13). Absence implies `full` for compatibility with v0.1 resolvers |
+| `batch_max_events` | integer | MAY | Advisory upper bound on events per batch CREATE/PUSH (cap is 1000 per §12.5; resolvers MAY enforce lower) |
+| `mtls_required` | boolean | MAY | If `true`, clients MUST present a TLS client cert (Section 12.8.1) |
+| `mtls_ca_bundle_url` | string | MAY | URL where the resolver publishes its CA bundle for client cert issuance (Section 12.8.1) |
 
 A resolver that does not publish `/meta` is still conformant. Clients
 that need a feature not advertised in `/meta` SHOULD attempt the

--- a/tests/conformance/LICENSE
+++ b/tests/conformance/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/tests/conformance/README.md
+++ b/tests/conformance/README.md
@@ -1,21 +1,34 @@
-# PhIP HTTP Conformance Suite
+# @phip/conformance
 
 A black-box test suite for PhIP servers. Any implementation that passes this
 suite against an empty namespace is wire-compatible with the reference
-resolver for the v0.1 scope: CREATE, GET, PUSH, QUERY, `/history/`, and
+resolver for the v0.1 scope: CREATE, GET, PUSH, QUERY, `/history/`, batch
+operations, `/meta`, `phip:access` enforcement, capability tokens, and
 error envelopes.
+
+## Install
+
+```
+npm install -g @phip/conformance
+```
+
+Or run directly from a clone of the [phip repo](https://github.com/mfgs-us/phip):
+
+```
+node tests/conformance/run.js <base-url>
+```
 
 ## Usage
 
 ```
-node conformance/run.js <base-url> [--namespace <ns>] [--authority <auth>]
+phip-conformance <base-url> [--namespace <ns>] [--authority <auth>]
 ```
 
 Example against a local reference server bound to `acme.example`:
 
 ```
 PHIP_AUTHORITY=acme.example PHIP_PORT=8080 node reference/src/index.js &
-node conformance/run.js http://127.0.0.1:8080 --authority acme.example
+phip-conformance http://127.0.0.1:8080 --authority acme.example
 ```
 
 * `<base-url>` — where the server is reachable over HTTP(S).

--- a/tests/conformance/package-lock.json
+++ b/tests/conformance/package-lock.json
@@ -1,0 +1,31 @@
+{
+  "name": "@phip/conformance",
+  "version": "0.1.0-draft",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@phip/conformance",
+      "version": "0.1.0-draft",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "canonicalize": "^2.0.0"
+      },
+      "bin": {
+        "phip-conformance": "run.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/canonicalize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-2.1.0.tgz",
+      "integrity": "sha512-F705O3xrsUtgt98j7leetNhTWPe+5S72rlL5O4jA1pKqBVQ/dT1O1D6PFxmSXvc0SUOinWS57DKx0I3CHrXJHQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "canonicalize": "bin/canonicalize.js"
+      }
+    }
+  }
+}

--- a/tests/conformance/package.json
+++ b/tests/conformance/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@phip/conformance",
+  "version": "0.1.0-draft",
+  "description": "PhIP HTTP conformance suite. Black-box tests any PhIP server's /.well-known/phip/* endpoints against the wire contract from spec sections 4, 10, 11, 12. Install globally and run against any resolver: phip-conformance http://my-server.example --authority my-authority.example",
+  "main": "run.js",
+  "bin": {
+    "phip-conformance": "run.js"
+  },
+  "files": [
+    "run.js",
+    "README.md"
+  ],
+  "scripts": {
+    "start": "node run.js"
+  },
+  "dependencies": {
+    "canonicalize": "^2.0.0"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "keywords": [
+    "phip",
+    "conformance",
+    "test-suite",
+    "federation"
+  ],
+  "homepage": "https://github.com/mfgs-us/phip/tree/main/tests/conformance",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mfgs-us/phip.git",
+    "directory": "tests/conformance"
+  },
+  "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/tests/conformance/package.json
+++ b/tests/conformance/package.json
@@ -8,7 +8,8 @@
   },
   "files": [
     "run.js",
-    "README.md"
+    "README.md",
+    "LICENSE"
   ],
   "scripts": {
     "start": "node run.js"

--- a/tests/conformance/run.js
+++ b/tests/conformance/run.js
@@ -30,7 +30,21 @@ const canonicalize = require("canonicalize");
 // MUST be overridable because PhIP authorities are names, not network
 // addresses — a server bound to authority "acme.example" can be reached at
 // http://localhost:8080 during testing.
+function printUsage() {
+  console.error(
+    "usage: phip-conformance <base-url> [--namespace <ns>] [--authority <auth>]\n" +
+    "\n" +
+    "  <base-url>     URL where the resolver is reachable (e.g. https://acme.example).\n" +
+    "  --namespace    Namespace to create test objects under. Default: 'conformance'.\n" +
+    "  --authority    PhIP authority name the resolver claims to be. Defaults to the\n" +
+    "                 URL hostname; override when network address ≠ authority name."
+  );
+}
 const raw = process.argv.slice(2);
+if (raw.length === 0 || raw.includes("--help") || raw.includes("-h")) {
+  printUsage();
+  process.exit(raw.length === 0 ? 2 : 0);
+}
 let BASE_URL = null;
 let NAMESPACE = "conformance";
 let AUTHORITY_OVERRIDE = null;
@@ -42,9 +56,7 @@ for (let i = 0; i < raw.length; i++) {
   else NAMESPACE = a;
 }
 if (!BASE_URL) {
-  console.error(
-    "usage: node conformance/run.js <base-url> [--namespace <ns>] [--authority <auth>]"
-  );
+  printUsage();
   process.exit(2);
 }
 

--- a/tests/conformance/run.js
+++ b/tests/conformance/run.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 // PhIP HTTP conformance suite.
 //
 // Exercises any PhIP server over HTTPS (or HTTP) to verify it implements the
@@ -5,8 +6,11 @@
 // black-box test — the server must only expose the standard endpoints under
 // /.well-known/phip/.
 //
-// Usage:   node conformance/run.js <base-url> [namespace]
-// Example: node conformance/run.js http://localhost:3000 conformance
+// Installed via `npm install -g @phip/conformance`, then:
+//   phip-conformance <base-url> [--namespace ns] [--authority host]
+//
+// Or run directly from a checkout:
+//   node conformance/run.js <base-url>
 //
 // The suite creates a self-signed bootstrap actor, then a component object,
 // pushes state transitions and attribute updates, reads history, runs
@@ -19,8 +23,6 @@
 const crypto = require("node:crypto");
 const http = require("node:http");
 const https = require("node:https");
-const path = require("node:path");
-const fs = require("node:fs");
 const canonicalize = require("canonicalize");
 
 // Parse argv: base-url is positional; namespace and authority can be
@@ -53,12 +55,18 @@ const AUTHORITY = AUTHORITY_OVERRIDE || new URL(BASE_URL).host.split(":")[0];
 const KEY_PHIP_ID = `phip://${AUTHORITY}/${NAMESPACE}/${KEY_LOCAL_ID}`;
 const OBJ_PHIP_ID = `phip://${AUTHORITY}/${NAMESPACE}/${OBJ_LOCAL_ID}`;
 
-// ── crypto helpers (using fixed test keypair from vectors) ────────────
-
-const keypairs = JSON.parse(
-  fs.readFileSync(path.join(__dirname, "..", "vectors", "ed25519", "keypair.json"), "utf8")
-).keys;
-const TESTKEY = keypairs[0];
+// ── crypto helpers ──────────────────────────────────────────────────
+//
+// The conformance suite needs a deterministic Ed25519 keypair for
+// signing the bootstrap actor's events. We embed one directly so the
+// package is self-contained when published — no dependency on the
+// vectors/ tree. This is the same `test-key-alice` keypair from
+// `tests/vectors/ed25519/keypair.json`, kept in sync.
+const TESTKEY = {
+  private_pkcs8_b64:
+    "MC4CAQAwBQYDK2VwBCIEILYVuTR2efrX2+iRiMd6EmrgZNMaFhxPi8HpoS/N7PUh",
+  public_raw_b64url: "-PMJVmvQQLw38uBOg3w4CXVk6CkadzUozxMUTzq96Ws",
+};
 
 const privateKey = crypto.createPrivateKey({
   key: Buffer.from(TESTKEY.private_pkcs8_b64, "base64"),
@@ -951,6 +959,72 @@ async function main() {
     rXfer.status === 201,
     `got ${rXfer.status}`,
   );
+
+  // ── 20. Federation mechanics (light, opt-in) ──────────────────────
+  // Full federation conformance (cross-authority token verification,
+  // redirect-chain following, mirror serving) requires standing up a
+  // counterpart authority — out of scope for a single-URL conformance
+  // run. Reference test scenarios live at
+  // https://github.com/mfgs-us/phip/blob/main/reference/test/federation.js
+  // and can be ported per-implementation.
+  //
+  // What we CAN test from a single URL: if the operator has configured
+  // their resolver with delegations or a transferred-successor, probe
+  // the redirect mechanics. Skipped if /meta does not advertise the
+  // relevant federation state.
+  console.log(`\n[20] federation mechanics (opt-in)`);
+  if (!metaPublished) {
+    console.log("  (skipped — /meta not published, can't detect federation config)");
+  } else {
+    if (Array.isArray(rMeta.body.delegations) && rMeta.body.delegations.length > 0) {
+      const d = rMeta.body.delegations[0];
+      const probeNs = d.namespace;
+      const probeId = (d.prefix || "") + "probe-" + RUN_ID;
+      const rDeleg = await request("GET", RESOLVE(probeNs, probeId));
+      test(
+        "delegation: GET to delegated slice returns 307",
+        rDeleg.status === 307,
+        `got ${rDeleg.status}`,
+      );
+      test(
+        "delegation: Location header points at delegate_authority",
+        rDeleg.headers && rDeleg.headers["location"]
+          && rDeleg.headers["location"].includes(d.delegate_authority),
+      );
+      test(
+        "delegation: PhIP-Delegation header carries the namespace",
+        rDeleg.headers && rDeleg.headers["phip-delegation"] === probeNs,
+      );
+    } else {
+      console.log("  (skipped delegation probe — /meta.delegations empty)");
+    }
+
+    if (rMeta.body.successor && rMeta.body.successor.authority) {
+      const succ = rMeta.body.successor;
+      const probeNs = (succ.namespaces && succ.namespaces[0]) || "any";
+      if (probeNs === "*") {
+        console.log("  (skipped successor probe — wildcard namespaces, no test target)");
+      } else {
+        const rXfer = await request("GET", RESOLVE(probeNs, "probe-" + RUN_ID));
+        test(
+          "successor: GET to transferred namespace returns 308",
+          rXfer.status === 308,
+          `got ${rXfer.status}`,
+        );
+        test(
+          "successor: Location header points at successor authority",
+          rXfer.headers && rXfer.headers["location"]
+            && rXfer.headers["location"].includes(succ.authority),
+        );
+        test(
+          "successor: PhIP-Transfer-Event header carries the event id",
+          rXfer.headers && rXfer.headers["phip-transfer-event"] === succ.transfer_event_id,
+        );
+      }
+    } else {
+      console.log("  (skipped successor probe — /meta.successor absent)");
+    }
+  }
 
   // ── summary ───────────────────────────────────────────────────────
   console.log(`\n${pass} passed, ${fail} failed`);

--- a/tests/package.json
+++ b/tests/package.json
@@ -2,7 +2,7 @@
   "name": "phip-tests",
   "version": "0.1.0-draft",
   "private": true,
-  "description": "Language-agnostic test vectors and HTTP conformance suite for PhIP. Fixtures in vectors/ are consumed by implementations in any language to verify byte-for-byte agreement on JCS, hashing, Ed25519 signing, URI parsing, hash chains, and lifecycle transitions. The conformance suite in conformance/ black-box tests any PhIP server over HTTP.",
+  "description": "Language-agnostic test vectors and HTTP conformance suite for PhIP. Fixtures in vectors/ are consumed by implementations in any language to verify byte-for-byte agreement on JCS, hashing, Ed25519 signing, URI parsing, hash chains, lifecycle transitions, capability tokens, and bundles. The conformance suite in conformance/ is also published as @phip/conformance — install globally via `npm install -g @phip/conformance` and run `phip-conformance <url>` against any resolver.",
   "scripts": {
     "generate": "node vectors/generate.js",
     "conformance": "node conformance/run.js",

--- a/tests/vectors/bundle/cases.json
+++ b/tests/vectors/bundle/cases.json
@@ -1,0 +1,305 @@
+{
+  "description": "PhIP bundle test vectors (Section 4.3.4). Bundles in production are tar archives on disk; here each bundle is represented as a single JSON document with the manifest, per-object state projections, per-object history events, and embedded key resources inlined. Implementations that pack/unpack the tar form MUST produce manifest bytes and signatures byte-identical to the inlined form here.\n\nVerification expectations per case:\n  - one-object: full chain verifies against manifest\n  - multi-object: full chain for both objects verifies\n  - tampered-event: manifest signature verifies BUT chain verification of widget-001 fails because the event payload was mutated after the manifest was produced",
+  "bundles": [
+    {
+      "name": "one-object",
+      "description": "Bundle: one-object",
+      "manifest": {
+        "bundle_version": "1.0",
+        "created_at": "2026-04-15T00:00:00Z",
+        "created_by": "phip://acme.example/keys/test-key-alice",
+        "authority": "acme.example",
+        "objects": [
+          {
+            "phip_id": "phip://acme.example/parts/widget-001",
+            "history_head": "sha256:a4745351866fe79f491c4a58af347b741617c22c0cf200fa233cc1b4c7e59948"
+          }
+        ],
+        "snapshot_of": "2026-04-15T00:00:00Z",
+        "signature": {
+          "algorithm": "Ed25519",
+          "key_id": "phip://acme.example/keys/test-key-alice",
+          "value": "lLvlQ4GNuMQTH89OB2zf5iqAyClE4ziZMlyuSs22r40yC8S6P7h2FOMwYjQSjAZkCj6U_2EdoVlbXlYDWdrAAA"
+        }
+      },
+      "objects": {
+        "phip://acme.example/parts/widget-001": {
+          "phip_id": "phip://acme.example/parts/widget-001",
+          "object_type": "component",
+          "state": "stock",
+          "identity": {
+            "serial": "WGT-001"
+          },
+          "relations": [],
+          "history_length": 1,
+          "history_head": "sha256:a4745351866fe79f491c4a58af347b741617c22c0cf200fa233cc1b4c7e59948"
+        }
+      },
+      "history": {
+        "phip://acme.example/parts/widget-001": [
+          {
+            "event_id": "30000000-0000-4000-a000-000000000001",
+            "phip_id": "phip://acme.example/parts/widget-001",
+            "type": "created",
+            "timestamp": "2026-04-01T00:00:00Z",
+            "actor": "phip://acme.example/keys/test-key-alice",
+            "previous_hash": "genesis",
+            "payload": {
+              "object_type": "component",
+              "state": "stock",
+              "identity": {
+                "serial": "WGT-001"
+              }
+            },
+            "signature": {
+              "algorithm": "Ed25519",
+              "key_id": "test-key-alice",
+              "value": "KhVBxZdWMzQSB8wKxoCpl1dol6_8PNew-KOfXdw5vXU3rnj0Kqqavbs7Lbf2ZEX_X03V4ctCZhLqQTjvT7YJDA"
+            }
+          }
+        ]
+      },
+      "keys": {
+        "phip://acme.example/keys/test-key-alice": {
+          "phip_id": "phip://acme.example/keys/test-key-alice",
+          "object_type": "actor",
+          "state": "active",
+          "attributes": {
+            "phip:keys": {
+              "kty": "OKP",
+              "crv": "Ed25519",
+              "x": "-PMJVmvQQLw38uBOg3w4CXVk6CkadzUozxMUTzq96Ws",
+              "not_before": "2026-01-01T00:00:00Z",
+              "not_after": "2030-01-01T00:00:00Z"
+            }
+          },
+          "history": []
+        }
+      }
+    },
+    {
+      "name": "multi-object",
+      "description": "Bundle: multi-object",
+      "manifest": {
+        "bundle_version": "1.0",
+        "created_at": "2026-04-15T00:00:00Z",
+        "created_by": "phip://acme.example/keys/test-key-alice",
+        "authority": "acme.example",
+        "objects": [
+          {
+            "phip_id": "phip://acme.example/parts/widget-001",
+            "history_head": "sha256:a4745351866fe79f491c4a58af347b741617c22c0cf200fa233cc1b4c7e59948"
+          },
+          {
+            "phip_id": "phip://acme.example/parts/widget-002",
+            "history_head": "sha256:a7bca0052129ebf8acee407803efa9ee58a4337e48e196e1f8f75b561de3c5a5"
+          }
+        ],
+        "signature": {
+          "algorithm": "Ed25519",
+          "key_id": "phip://acme.example/keys/test-key-alice",
+          "value": "RzSHfu4MItsbxFXu-2gxPznE5ObH9anllA35ewrhcNM3vN1eMQZ58nB-fMAEPWCn_CsmnegxR5Epx-xyH5RtBQ"
+        }
+      },
+      "objects": {
+        "phip://acme.example/parts/widget-001": {
+          "phip_id": "phip://acme.example/parts/widget-001",
+          "object_type": "component",
+          "state": "stock",
+          "identity": {
+            "serial": "WGT-001"
+          },
+          "relations": [],
+          "history_length": 1,
+          "history_head": "sha256:a4745351866fe79f491c4a58af347b741617c22c0cf200fa233cc1b4c7e59948"
+        },
+        "phip://acme.example/parts/widget-002": {
+          "phip_id": "phip://acme.example/parts/widget-002",
+          "object_type": "component",
+          "state": "stock",
+          "identity": {
+            "serial": "WGT-002"
+          },
+          "relations": [],
+          "history_length": 1,
+          "history_head": "sha256:a7bca0052129ebf8acee407803efa9ee58a4337e48e196e1f8f75b561de3c5a5"
+        }
+      },
+      "history": {
+        "phip://acme.example/parts/widget-001": [
+          {
+            "event_id": "30000000-0000-4000-a000-000000000001",
+            "phip_id": "phip://acme.example/parts/widget-001",
+            "type": "created",
+            "timestamp": "2026-04-01T00:00:00Z",
+            "actor": "phip://acme.example/keys/test-key-alice",
+            "previous_hash": "genesis",
+            "payload": {
+              "object_type": "component",
+              "state": "stock",
+              "identity": {
+                "serial": "WGT-001"
+              }
+            },
+            "signature": {
+              "algorithm": "Ed25519",
+              "key_id": "test-key-alice",
+              "value": "KhVBxZdWMzQSB8wKxoCpl1dol6_8PNew-KOfXdw5vXU3rnj0Kqqavbs7Lbf2ZEX_X03V4ctCZhLqQTjvT7YJDA"
+            }
+          }
+        ],
+        "phip://acme.example/parts/widget-002": [
+          {
+            "event_id": "30000000-0000-4000-a000-000000000002",
+            "phip_id": "phip://acme.example/parts/widget-002",
+            "type": "created",
+            "timestamp": "2026-04-02T00:00:00Z",
+            "actor": "phip://acme.example/keys/test-key-alice",
+            "previous_hash": "genesis",
+            "payload": {
+              "object_type": "component",
+              "state": "stock",
+              "identity": {
+                "serial": "WGT-002"
+              }
+            },
+            "signature": {
+              "algorithm": "Ed25519",
+              "key_id": "test-key-alice",
+              "value": "eSONT0z6h4ESKMFbEXf0rcAwnS8wY4JvqicUxr8Q1HuBoTOB1m6-u2bavp0-cv-6HydgaxKVU7wV4_jNF7M5CA"
+            }
+          }
+        ]
+      },
+      "keys": {
+        "phip://acme.example/keys/test-key-alice": {
+          "phip_id": "phip://acme.example/keys/test-key-alice",
+          "object_type": "actor",
+          "state": "active",
+          "attributes": {
+            "phip:keys": {
+              "kty": "OKP",
+              "crv": "Ed25519",
+              "x": "-PMJVmvQQLw38uBOg3w4CXVk6CkadzUozxMUTzq96Ws",
+              "not_before": "2026-01-01T00:00:00Z",
+              "not_after": "2030-01-01T00:00:00Z"
+            }
+          },
+          "history": []
+        }
+      }
+    },
+    {
+      "name": "tampered-event",
+      "description": "Bundle: tampered-event (event mutated post-signing)",
+      "manifest": {
+        "bundle_version": "1.0",
+        "created_at": "2026-04-15T00:00:00Z",
+        "created_by": "phip://acme.example/keys/test-key-alice",
+        "authority": "acme.example",
+        "objects": [
+          {
+            "phip_id": "phip://acme.example/parts/widget-001",
+            "history_head": "sha256:a4745351866fe79f491c4a58af347b741617c22c0cf200fa233cc1b4c7e59948"
+          },
+          {
+            "phip_id": "phip://acme.example/parts/widget-002",
+            "history_head": "sha256:a7bca0052129ebf8acee407803efa9ee58a4337e48e196e1f8f75b561de3c5a5"
+          }
+        ],
+        "signature": {
+          "algorithm": "Ed25519",
+          "key_id": "phip://acme.example/keys/test-key-alice",
+          "value": "RzSHfu4MItsbxFXu-2gxPznE5ObH9anllA35ewrhcNM3vN1eMQZ58nB-fMAEPWCn_CsmnegxR5Epx-xyH5RtBQ"
+        }
+      },
+      "objects": {
+        "phip://acme.example/parts/widget-001": {
+          "phip_id": "phip://acme.example/parts/widget-001",
+          "object_type": "component",
+          "state": "stock",
+          "identity": {
+            "serial": "WGT-001"
+          },
+          "relations": [],
+          "history_length": 1,
+          "history_head": "sha256:a4745351866fe79f491c4a58af347b741617c22c0cf200fa233cc1b4c7e59948"
+        },
+        "phip://acme.example/parts/widget-002": {
+          "phip_id": "phip://acme.example/parts/widget-002",
+          "object_type": "component",
+          "state": "stock",
+          "identity": {
+            "serial": "WGT-002"
+          },
+          "relations": [],
+          "history_length": 1,
+          "history_head": "sha256:a7bca0052129ebf8acee407803efa9ee58a4337e48e196e1f8f75b561de3c5a5"
+        }
+      },
+      "history": {
+        "phip://acme.example/parts/widget-001": [
+          {
+            "event_id": "30000000-0000-4000-a000-000000000001",
+            "phip_id": "phip://acme.example/parts/widget-001",
+            "type": "created",
+            "timestamp": "2026-04-01T00:00:00Z",
+            "actor": "phip://acme.example/keys/test-key-alice",
+            "previous_hash": "genesis",
+            "payload": {
+              "object_type": "component",
+              "state": "stock",
+              "identity": {
+                "serial": "WGT-FORGED"
+              }
+            },
+            "signature": {
+              "algorithm": "Ed25519",
+              "key_id": "test-key-alice",
+              "value": "KhVBxZdWMzQSB8wKxoCpl1dol6_8PNew-KOfXdw5vXU3rnj0Kqqavbs7Lbf2ZEX_X03V4ctCZhLqQTjvT7YJDA"
+            }
+          }
+        ],
+        "phip://acme.example/parts/widget-002": [
+          {
+            "event_id": "30000000-0000-4000-a000-000000000002",
+            "phip_id": "phip://acme.example/parts/widget-002",
+            "type": "created",
+            "timestamp": "2026-04-02T00:00:00Z",
+            "actor": "phip://acme.example/keys/test-key-alice",
+            "previous_hash": "genesis",
+            "payload": {
+              "object_type": "component",
+              "state": "stock",
+              "identity": {
+                "serial": "WGT-002"
+              }
+            },
+            "signature": {
+              "algorithm": "Ed25519",
+              "key_id": "test-key-alice",
+              "value": "eSONT0z6h4ESKMFbEXf0rcAwnS8wY4JvqicUxr8Q1HuBoTOB1m6-u2bavp0-cv-6HydgaxKVU7wV4_jNF7M5CA"
+            }
+          }
+        ]
+      },
+      "keys": {
+        "phip://acme.example/keys/test-key-alice": {
+          "phip_id": "phip://acme.example/keys/test-key-alice",
+          "object_type": "actor",
+          "state": "active",
+          "attributes": {
+            "phip:keys": {
+              "kty": "OKP",
+              "crv": "Ed25519",
+              "x": "-PMJVmvQQLw38uBOg3w4CXVk6CkadzUozxMUTzq96Ws",
+              "not_before": "2026-01-01T00:00:00Z",
+              "not_after": "2030-01-01T00:00:00Z"
+            }
+          },
+          "history": []
+        }
+      }
+    }
+  ]
+}

--- a/tests/vectors/generate.js
+++ b/tests/vectors/generate.js
@@ -698,6 +698,7 @@ const tokenCases = [];
     verifying_key_id: "test-key-alice",
     verification_time: "2026-06-01T00:00:00Z",
     expected: "invalid_signature",
+    notes: "The signed_token JSON shown is the post-mutation form (scope='push_events'). The signature was computed over the pre-mutation form (scope='read_state'); verifying against the displayed content fails by design.",
   });
 }
 

--- a/tests/vectors/generate.js
+++ b/tests/vectors/generate.js
@@ -548,4 +548,381 @@ writeJson("bootstrap/example.json", {
   created_event: bootstrapCreated,
 });
 
+// ─────────────────────────────────────────────────────────────────────
+// 9. Capability token verification — Section 11.3
+// ─────────────────────────────────────────────────────────────────────
+//
+// A token is a JSON object base64url-encoded for transport in the
+// `Authorization: PhIP-Capability <token>` header. Each case here gives
+// the signed token (object form), its base64url-encoded transport form,
+// the key that should verify the signature, and the expected outcome
+// after a full §11.3.4 check sequence.
+//
+// `verification_time` is the ISO 8601 instant the verifier should
+// pretend "now" is — needed for deterministic expired/not-yet-valid
+// outcomes.
+
+function signToken(unsigned, keyId) {
+  const key = getKey(keyId);
+  const { signature, ...rest } = unsigned;
+  const sig = crypto.sign(null, canonicalBytes(rest), key.privateKey);
+  return {
+    ...rest,
+    signature: {
+      algorithm: "Ed25519",
+      key_id: `phip://acme.example/keys/${keyId}`,
+      value: sig.toString("base64url"),
+    },
+  };
+}
+
+function tokenB64(token) {
+  return Buffer.from(JSON.stringify(token), "utf8").toString("base64url");
+}
+
+const ALICE_KEY_URI = "phip://acme.example/keys/test-key-alice";
+const BOB_KEY_URI = "phip://other.example/keys/test-key-bob";
+
+// Base "valid" token shape — variants tweak fields.
+const baseToken = {
+  phip_capability: "1.0",
+  token_id: "00000000-0000-4000-a000-000000000001",
+  granted_by: ALICE_KEY_URI,
+  granted_to: ALICE_KEY_URI,
+  scope: "push_events",
+  object_filter: "phip://acme.example/parts/*",
+  not_before: "2026-01-15T00:00:00Z",
+  expires: "2026-12-31T23:59:59Z",
+};
+
+const tokenCases = [];
+
+// 1. Valid push token, intra-authority signer.
+{
+  const t = signToken({ ...baseToken }, "test-key-alice");
+  tokenCases.push({
+    name: "valid-push-token",
+    signed_token: t,
+    transport_b64url: tokenB64(t),
+    verifying_key_id: "test-key-alice",
+    verification_time: "2026-06-01T00:00:00Z",
+    expected: "valid",
+  });
+}
+
+// 2. Valid read_state token.
+{
+  const t = signToken(
+    { ...baseToken, token_id: "00000000-0000-4000-a000-000000000002", scope: "read_state" },
+    "test-key-alice",
+  );
+  tokenCases.push({
+    name: "valid-read-state-token",
+    signed_token: t,
+    transport_b64url: tokenB64(t),
+    verifying_key_id: "test-key-alice",
+    verification_time: "2026-06-01T00:00:00Z",
+    expected: "valid",
+  });
+}
+
+// 3. Expired token (verification time after `expires`).
+{
+  const t = signToken({ ...baseToken, token_id: "00000000-0000-4000-a000-000000000003" }, "test-key-alice");
+  tokenCases.push({
+    name: "expired-token",
+    signed_token: t,
+    transport_b64url: tokenB64(t),
+    verifying_key_id: "test-key-alice",
+    verification_time: "2027-01-01T00:00:00Z",
+    expected: "expired",
+  });
+}
+
+// 4. Not-yet-valid token (verification time before `not_before`).
+{
+  const t = signToken({ ...baseToken, token_id: "00000000-0000-4000-a000-000000000004" }, "test-key-alice");
+  tokenCases.push({
+    name: "not-yet-valid-token",
+    signed_token: t,
+    transport_b64url: tokenB64(t),
+    verifying_key_id: "test-key-alice",
+    verification_time: "2025-01-01T00:00:00Z",
+    expected: "not_yet_valid",
+  });
+}
+
+// 5. Object filter does not match the requested object.
+{
+  const t = signToken(
+    { ...baseToken, token_id: "00000000-0000-4000-a000-000000000005", object_filter: "phip://acme.example/lots/*" },
+    "test-key-alice",
+  );
+  tokenCases.push({
+    name: "object-filter-mismatch",
+    signed_token: t,
+    transport_b64url: tokenB64(t),
+    verifying_key_id: "test-key-alice",
+    verification_time: "2026-06-01T00:00:00Z",
+    requested_object: "phip://acme.example/parts/widget-001",
+    expected: "object_filter_mismatch",
+  });
+}
+
+// 6. Forged signature (correct shape, garbage signature bytes).
+{
+  const t = signToken({ ...baseToken, token_id: "00000000-0000-4000-a000-000000000006" }, "test-key-alice");
+  t.signature.value = Buffer.alloc(64, 0).toString("base64url");
+  tokenCases.push({
+    name: "forged-signature",
+    signed_token: t,
+    transport_b64url: tokenB64(t),
+    verifying_key_id: "test-key-alice",
+    verification_time: "2026-06-01T00:00:00Z",
+    expected: "invalid_signature",
+  });
+}
+
+// 7. Tampered token (sign with one body, then mutate a field — sig fails).
+{
+  const t = signToken(
+    { ...baseToken, token_id: "00000000-0000-4000-a000-000000000007", scope: "read_state" },
+    "test-key-alice",
+  );
+  // Mutate scope after signing — verification must fail.
+  t.scope = "push_events";
+  tokenCases.push({
+    name: "tampered-after-signing",
+    signed_token: t,
+    transport_b64url: tokenB64(t),
+    verifying_key_id: "test-key-alice",
+    verification_time: "2026-06-01T00:00:00Z",
+    expected: "invalid_signature",
+  });
+}
+
+// 8. Read scope coverage: read_history covers read_state. (Validity check
+//    only — the actual scope-coverage logic is enforced server-side.)
+{
+  const t = signToken(
+    { ...baseToken, token_id: "00000000-0000-4000-a000-000000000008", scope: "read_history" },
+    "test-key-alice",
+  );
+  tokenCases.push({
+    name: "read-history-token",
+    signed_token: t,
+    transport_b64url: tokenB64(t),
+    verifying_key_id: "test-key-alice",
+    verification_time: "2026-06-01T00:00:00Z",
+    requested_scope: "read_state",
+    expected: "valid",
+  });
+}
+
+// 9. Foreign signer (key_id at another authority). Verification requires
+//    federation; intra-authority resolvers MUST reject with
+//    INVALID_CAPABILITY rather than verifying against a local key.
+{
+  const t = signToken({ ...baseToken, token_id: "00000000-0000-4000-a000-000000000009" }, "test-key-bob");
+  t.signature.key_id = BOB_KEY_URI;
+  tokenCases.push({
+    name: "foreign-signer-token",
+    signed_token: t,
+    transport_b64url: tokenB64(t),
+    verifying_key_id: "test-key-bob",
+    verification_time: "2026-06-01T00:00:00Z",
+    expected: "valid",
+    notes: "Intra-authority resolvers without federation MUST reject as INVALID_CAPABILITY. Federated resolvers fetch test-key-bob's actor and verify; result is valid.",
+  });
+}
+
+writeJson("token/cases.json", {
+  description:
+    "Capability token verification cases per Section 11.3.4. Each case " +
+    "gives the signed token (JSON object form), its base64url-encoded " +
+    "transport form (the value placed in the Authorization header), the " +
+    "key id whose public key verifies the signature, and the expected " +
+    "outcome after a full verification sequence at the given " +
+    "`verification_time`. Implementations MUST produce identical " +
+    "verification results given the same inputs.",
+  cases: tokenCases,
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// 10. PhIP bundle — Section 4.3.4
+// ─────────────────────────────────────────────────────────────────────
+//
+// A PhIP bundle is a signed archive of object states + their event
+// histories + key resources. The transport format is a tar archive on
+// disk; for the test vectors we represent the same content as a single
+// JSON document (`bundle/example.json`) with the manifest, objects,
+// histories, and keys inlined. Implementations that pack/unpack the
+// tar form MUST produce manifest bytes and signatures byte-identical
+// to the inlined form here.
+//
+// Cases:
+//   - one-object  : single component object, single key
+//   - multi-object: two objects sharing the same signing key
+//   - tampered    : valid bundle with one event mutated post-signing
+//                   (used to assert verification rejects)
+
+const BUNDLE_AUTHORITY = "acme.example";
+const BUNDLE_PRODUCER_KEY_PHIP = `phip://${BUNDLE_AUTHORITY}/keys/test-key-alice`;
+
+function buildBundle({ name, objects, producerKeyId, snapshotOf }) {
+  // Each `object` here is the result of running a small history (genesis
+  // CREATE only, in this minimal generator). Bundles in production
+  // typically include richer histories; the test vectors keep it small
+  // for clarity.
+  const objectEntries = objects.map((o) => o.event);
+  const keys = {};
+  // Embed the producer's key actor so the bundle is self-verifying.
+  keys[BUNDLE_PRODUCER_KEY_PHIP] = {
+    phip_id: BUNDLE_PRODUCER_KEY_PHIP,
+    object_type: "actor",
+    state: "active",
+    attributes: {
+      "phip:keys": {
+        kty: "OKP",
+        crv: "Ed25519",
+        x: getKey(producerKeyId).public_raw_b64url,
+        not_before: "2026-01-01T00:00:00Z",
+        not_after: "2030-01-01T00:00:00Z",
+      },
+    },
+    history: [],
+  };
+
+  // Manifest fields excluding signature.
+  const manifestUnsigned = {
+    bundle_version: "1.0",
+    created_at: "2026-04-15T00:00:00Z",
+    created_by: BUNDLE_PRODUCER_KEY_PHIP,
+    authority: BUNDLE_AUTHORITY,
+    objects: objectEntries.map((e) => ({
+      phip_id: e.phip_id,
+      history_head: hashEvent(e),
+    })),
+  };
+  if (snapshotOf) manifestUnsigned.snapshot_of = snapshotOf;
+
+  const sig = crypto.sign(
+    null,
+    canonicalBytes(manifestUnsigned),
+    getKey(producerKeyId).privateKey,
+  );
+  const manifest = {
+    ...manifestUnsigned,
+    signature: {
+      algorithm: "Ed25519",
+      key_id: BUNDLE_PRODUCER_KEY_PHIP,
+      value: sig.toString("base64url"),
+    },
+  };
+
+  // Per-object projections (state at history_head).
+  const objectProjections = {};
+  const historyJsonl = {};
+  for (const e of objectEntries) {
+    objectProjections[e.phip_id] = {
+      phip_id: e.phip_id,
+      object_type: e.payload.object_type,
+      state: e.payload.state,
+      identity: e.payload.identity || undefined,
+      attributes: e.payload.attributes || undefined,
+      relations: e.payload.relations || [],
+      history_length: 1,
+      history_head: hashEvent(e),
+    };
+    historyJsonl[e.phip_id] = [e]; // single event per object in this minimal vector
+  }
+
+  return {
+    name,
+    description: `Bundle: ${name}`,
+    manifest,
+    objects: objectProjections,
+    history: historyJsonl,
+    keys,
+  };
+}
+
+// Build a couple of objects to bundle.
+const bundleObj1Phip = `phip://${BUNDLE_AUTHORITY}/parts/widget-001`;
+const bundleObj1 = signEvent(
+  {
+    event_id: "30000000-0000-4000-a000-000000000001",
+    phip_id: bundleObj1Phip,
+    type: "created",
+    timestamp: "2026-04-01T00:00:00Z",
+    actor: BUNDLE_PRODUCER_KEY_PHIP,
+    previous_hash: "genesis",
+    payload: {
+      object_type: "component",
+      state: "stock",
+      identity: { serial: "WGT-001" },
+    },
+  },
+  "test-key-alice",
+);
+
+const bundleObj2Phip = `phip://${BUNDLE_AUTHORITY}/parts/widget-002`;
+const bundleObj2 = signEvent(
+  {
+    event_id: "30000000-0000-4000-a000-000000000002",
+    phip_id: bundleObj2Phip,
+    type: "created",
+    timestamp: "2026-04-02T00:00:00Z",
+    actor: BUNDLE_PRODUCER_KEY_PHIP,
+    previous_hash: "genesis",
+    payload: {
+      object_type: "component",
+      state: "stock",
+      identity: { serial: "WGT-002" },
+    },
+  },
+  "test-key-alice",
+);
+
+// Bundle 1: single object.
+const oneObjectBundle = buildBundle({
+  name: "one-object",
+  objects: [{ event: bundleObj1 }],
+  producerKeyId: "test-key-alice",
+  snapshotOf: "2026-04-15T00:00:00Z",
+});
+
+// Bundle 2: multi-object snapshot.
+const multiObjectBundle = buildBundle({
+  name: "multi-object",
+  objects: [{ event: bundleObj1 }, { event: bundleObj2 }],
+  producerKeyId: "test-key-alice",
+});
+
+// Bundle 3: tampered — valid manifest signature, but one event was mutated
+// post-bundling. Consumers MUST reject during chain verification, not
+// during manifest verification.
+const tamperedBundle = JSON.parse(JSON.stringify(multiObjectBundle));
+tamperedBundle.name = "tampered-event";
+tamperedBundle.description = "Bundle: tampered-event (event mutated post-signing)";
+// Mutate one event's payload field after the manifest was signed.
+tamperedBundle.history[bundleObj1Phip][0].payload.identity.serial = "WGT-FORGED";
+
+writeJson("bundle/cases.json", {
+  description:
+    "PhIP bundle test vectors (Section 4.3.4). Bundles in production are " +
+    "tar archives on disk; here each bundle is represented as a single " +
+    "JSON document with the manifest, per-object state projections, " +
+    "per-object history events, and embedded key resources inlined. " +
+    "Implementations that pack/unpack the tar form MUST produce manifest " +
+    "bytes and signatures byte-identical to the inlined form here.\n\n" +
+    "Verification expectations per case:\n" +
+    "  - one-object: full chain verifies against manifest\n" +
+    "  - multi-object: full chain for both objects verifies\n" +
+    "  - tampered-event: manifest signature verifies BUT chain " +
+    "verification of widget-001 fails because the event payload was " +
+    "mutated after the manifest was produced",
+  bundles: [oneObjectBundle, multiObjectBundle, tamperedBundle],
+});
+
 console.log("\nall vectors written.");

--- a/tests/vectors/self-check.js
+++ b/tests/vectors/self-check.js
@@ -203,5 +203,137 @@ console.log("\n[lifecycle]");
   }
 }
 
+// ── Capability tokens ──────────────────────────────────────────────
+console.log("\n[token]");
+{
+  const { keys } = load("ed25519/keypair.json");
+  const keyMap = Object.fromEntries(keys.map((k) => [k.id, loadKey(k)]));
+  const { cases } = load("token/cases.json");
+  for (const c of cases) {
+    // Verify signature reproducibility against the named verifying key.
+    const verifyingKey = keyMap[c.verifying_key_id];
+    const { signature, ...rest } = c.signed_token;
+    const verified = crypto.verify(
+      null,
+      Buffer.from(canonicalize(rest), "utf8"),
+      verifyingKey.publicKey,
+      Buffer.from(signature.value, "base64url"),
+    );
+    // Cases with expected = invalid_signature MUST NOT verify.
+    // Cases with any other expected value MUST verify (the rejection
+    // happens at higher-level checks: expiry, scope, filter, etc.)
+    const sigShouldVerify = c.expected !== "invalid_signature";
+    assert(
+      verified === sigShouldVerify,
+      `token ${c.name} signature ${sigShouldVerify ? "verifies" : "does not verify"}`,
+    );
+
+    // Transport round-trip: base64url-decoded transport form MUST parse
+    // back to the same JSON.
+    const decoded = JSON.parse(Buffer.from(c.transport_b64url, "base64url").toString("utf8"));
+    assert(
+      JSON.stringify(decoded) === JSON.stringify(c.signed_token),
+      `token ${c.name} transport_b64url round-trips to signed_token`,
+    );
+
+    // Time-window checks: assert the case's `verification_time` matches
+    // the expected outcome by spec rule.
+    if (c.expected === "expired") {
+      assert(
+        Date.parse(c.verification_time) > Date.parse(c.signed_token.expires),
+        `token ${c.name} verification_time is after expires`,
+      );
+    } else if (c.expected === "not_yet_valid") {
+      assert(
+        Date.parse(c.verification_time) < Date.parse(c.signed_token.not_before),
+        `token ${c.name} verification_time is before not_before`,
+      );
+    }
+  }
+}
+
+// ── Bundles ────────────────────────────────────────────────────────
+console.log("\n[bundle]");
+{
+  const { keys: testKeys } = load("ed25519/keypair.json");
+  const keyMap = Object.fromEntries(testKeys.map((k) => [k.id, loadKey(k)]));
+  const aliceJwkX = testKeys.find((k) => k.id === "test-key-alice").public_raw_b64url;
+  const alicePub = (() => {
+    const raw = Buffer.from(aliceJwkX, "base64url");
+    const spki = Buffer.concat([
+      Buffer.from("302a300506032b6570032100", "hex"),
+      raw,
+    ]);
+    return crypto.createPublicKey({ key: spki, format: "der", type: "spki" });
+  })();
+  void keyMap;
+
+  const { bundles } = load("bundle/cases.json");
+  for (const b of bundles) {
+    // Step 1: manifest signature MUST verify in all cases (the tampered
+    // case mutates events, not the manifest).
+    const { signature, ...manifestRest } = b.manifest;
+    const manifestVerified = crypto.verify(
+      null,
+      Buffer.from(canonicalize(manifestRest), "utf8"),
+      alicePub,
+      Buffer.from(signature.value, "base64url"),
+    );
+    assert(manifestVerified, `bundle ${b.name} manifest signature verifies`);
+
+    // Step 2: each declared object's history MUST hash-chain to the
+    // manifest's claimed history_head.
+    let chainOk = true;
+    for (const objEntry of b.manifest.objects) {
+      const events = b.history[objEntry.phip_id];
+      if (!events || !events.length) {
+        chainOk = false;
+        break;
+      }
+      // Walk the chain forward, verifying each event signature and
+      // each previous_hash linkage.
+      for (let i = 0; i < events.length; i++) {
+        const ev = events[i];
+        const prevHash = i === 0 ? "genesis" : hashEvent(events[i - 1]);
+        if (ev.previous_hash !== prevHash) {
+          chainOk = false;
+          break;
+        }
+        const { signature: evSig, ...evRest } = ev;
+        const sigOk = crypto.verify(
+          null,
+          Buffer.from(canonicalize(evRest), "utf8"),
+          alicePub,
+          Buffer.from(evSig.value, "base64url"),
+        );
+        if (!sigOk) {
+          chainOk = false;
+          break;
+        }
+      }
+      // Final head matches the manifest's claim.
+      const finalHead = hashEvent(events[events.length - 1]);
+      if (finalHead !== objEntry.history_head) {
+        chainOk = false;
+      }
+      if (!chainOk) break;
+    }
+
+    if (b.name === "tampered-event") {
+      assert(!chainOk, `bundle ${b.name} chain verification REJECTS (tampered event)`);
+    } else {
+      assert(chainOk, `bundle ${b.name} chain verification accepts`);
+    }
+
+    // Step 3: embedded keys MUST contain the producer's key actor.
+    const producerKeyUri = b.manifest.created_by;
+    const producerKey = b.keys[producerKeyUri];
+    assert(
+      producerKey && producerKey.attributes && producerKey.attributes["phip:keys"],
+      `bundle ${b.name} embeds producer's key actor`,
+    );
+  }
+}
+
 console.log(`\n${pass} passed, ${fail} failed`);
 process.exit(fail === 0 ? 0 : 1);

--- a/tests/vectors/token/cases.json
+++ b/tests/vectors/token/cases.json
@@ -154,7 +154,8 @@
       "transport_b64url": "eyJwaGlwX2NhcGFiaWxpdHkiOiIxLjAiLCJ0b2tlbl9pZCI6IjAwMDAwMDAwLTAwMDAtNDAwMC1hMDAwLTAwMDAwMDAwMDAwNyIsImdyYW50ZWRfYnkiOiJwaGlwOi8vYWNtZS5leGFtcGxlL2tleXMvdGVzdC1rZXktYWxpY2UiLCJncmFudGVkX3RvIjoicGhpcDovL2FjbWUuZXhhbXBsZS9rZXlzL3Rlc3Qta2V5LWFsaWNlIiwic2NvcGUiOiJwdXNoX2V2ZW50cyIsIm9iamVjdF9maWx0ZXIiOiJwaGlwOi8vYWNtZS5leGFtcGxlL3BhcnRzLyoiLCJub3RfYmVmb3JlIjoiMjAyNi0wMS0xNVQwMDowMDowMFoiLCJleHBpcmVzIjoiMjAyNi0xMi0zMVQyMzo1OTo1OVoiLCJzaWduYXR1cmUiOnsiYWxnb3JpdGhtIjoiRWQyNTUxOSIsImtleV9pZCI6InBoaXA6Ly9hY21lLmV4YW1wbGUva2V5cy90ZXN0LWtleS1hbGljZSIsInZhbHVlIjoiRzZqZkt2WXN4dzBjUmZxNXVEbERKa3JMbXU3UmZrOTl5TFltWU9raURNVmdEQ3lWZDNtTllVSlo1YmNBNlIwRFRnbnZNSi1ZZW9ySnpyNVgwYVE0Q3cifX0",
       "verifying_key_id": "test-key-alice",
       "verification_time": "2026-06-01T00:00:00Z",
-      "expected": "invalid_signature"
+      "expected": "invalid_signature",
+      "notes": "The signed_token JSON shown is the post-mutation form (scope='push_events'). The signature was computed over the pre-mutation form (scope='read_state'); verifying against the displayed content fails by design."
     },
     {
       "name": "read-history-token",

--- a/tests/vectors/token/cases.json
+++ b/tests/vectors/token/cases.json
@@ -1,0 +1,206 @@
+{
+  "description": "Capability token verification cases per Section 11.3.4. Each case gives the signed token (JSON object form), its base64url-encoded transport form (the value placed in the Authorization header), the key id whose public key verifies the signature, and the expected outcome after a full verification sequence at the given `verification_time`. Implementations MUST produce identical verification results given the same inputs.",
+  "cases": [
+    {
+      "name": "valid-push-token",
+      "signed_token": {
+        "phip_capability": "1.0",
+        "token_id": "00000000-0000-4000-a000-000000000001",
+        "granted_by": "phip://acme.example/keys/test-key-alice",
+        "granted_to": "phip://acme.example/keys/test-key-alice",
+        "scope": "push_events",
+        "object_filter": "phip://acme.example/parts/*",
+        "not_before": "2026-01-15T00:00:00Z",
+        "expires": "2026-12-31T23:59:59Z",
+        "signature": {
+          "algorithm": "Ed25519",
+          "key_id": "phip://acme.example/keys/test-key-alice",
+          "value": "E8hXXLWVK-0Pd_ofRDY2-pvul0vWYKWv23CV0YR7CUVjZP-wMWCFA11bdYlVDhgUIo3yDfirQVpkFXcoyRjPDA"
+        }
+      },
+      "transport_b64url": "eyJwaGlwX2NhcGFiaWxpdHkiOiIxLjAiLCJ0b2tlbl9pZCI6IjAwMDAwMDAwLTAwMDAtNDAwMC1hMDAwLTAwMDAwMDAwMDAwMSIsImdyYW50ZWRfYnkiOiJwaGlwOi8vYWNtZS5leGFtcGxlL2tleXMvdGVzdC1rZXktYWxpY2UiLCJncmFudGVkX3RvIjoicGhpcDovL2FjbWUuZXhhbXBsZS9rZXlzL3Rlc3Qta2V5LWFsaWNlIiwic2NvcGUiOiJwdXNoX2V2ZW50cyIsIm9iamVjdF9maWx0ZXIiOiJwaGlwOi8vYWNtZS5leGFtcGxlL3BhcnRzLyoiLCJub3RfYmVmb3JlIjoiMjAyNi0wMS0xNVQwMDowMDowMFoiLCJleHBpcmVzIjoiMjAyNi0xMi0zMVQyMzo1OTo1OVoiLCJzaWduYXR1cmUiOnsiYWxnb3JpdGhtIjoiRWQyNTUxOSIsImtleV9pZCI6InBoaXA6Ly9hY21lLmV4YW1wbGUva2V5cy90ZXN0LWtleS1hbGljZSIsInZhbHVlIjoiRThoWFhMV1ZLLTBQZF9vZlJEWTItcHZ1bDB2V1lLV3YyM0NWMFlSN0NVVmpaUC13TVdDRkExMWJkWWxWRGhnVUlvM3lEZmlyUVZwa0ZYY295UmpQREEifX0",
+      "verifying_key_id": "test-key-alice",
+      "verification_time": "2026-06-01T00:00:00Z",
+      "expected": "valid"
+    },
+    {
+      "name": "valid-read-state-token",
+      "signed_token": {
+        "phip_capability": "1.0",
+        "token_id": "00000000-0000-4000-a000-000000000002",
+        "granted_by": "phip://acme.example/keys/test-key-alice",
+        "granted_to": "phip://acme.example/keys/test-key-alice",
+        "scope": "read_state",
+        "object_filter": "phip://acme.example/parts/*",
+        "not_before": "2026-01-15T00:00:00Z",
+        "expires": "2026-12-31T23:59:59Z",
+        "signature": {
+          "algorithm": "Ed25519",
+          "key_id": "phip://acme.example/keys/test-key-alice",
+          "value": "zT1h9lt-mL19ZkvWkQbBTsg1YreXFBd1k2vL4gulSLWGZnvltgVxqaww8mjtudGUq12xynr0ErMzbxiFwtysAg"
+        }
+      },
+      "transport_b64url": "eyJwaGlwX2NhcGFiaWxpdHkiOiIxLjAiLCJ0b2tlbl9pZCI6IjAwMDAwMDAwLTAwMDAtNDAwMC1hMDAwLTAwMDAwMDAwMDAwMiIsImdyYW50ZWRfYnkiOiJwaGlwOi8vYWNtZS5leGFtcGxlL2tleXMvdGVzdC1rZXktYWxpY2UiLCJncmFudGVkX3RvIjoicGhpcDovL2FjbWUuZXhhbXBsZS9rZXlzL3Rlc3Qta2V5LWFsaWNlIiwic2NvcGUiOiJyZWFkX3N0YXRlIiwib2JqZWN0X2ZpbHRlciI6InBoaXA6Ly9hY21lLmV4YW1wbGUvcGFydHMvKiIsIm5vdF9iZWZvcmUiOiIyMDI2LTAxLTE1VDAwOjAwOjAwWiIsImV4cGlyZXMiOiIyMDI2LTEyLTMxVDIzOjU5OjU5WiIsInNpZ25hdHVyZSI6eyJhbGdvcml0aG0iOiJFZDI1NTE5Iiwia2V5X2lkIjoicGhpcDovL2FjbWUuZXhhbXBsZS9rZXlzL3Rlc3Qta2V5LWFsaWNlIiwidmFsdWUiOiJ6VDFoOWx0LW1MMTlaa3ZXa1FiQlRzZzFZcmVYRkJkMWsydkw0Z3VsU0xXR1pudmx0Z1Z4cWF3dzhtanR1ZEdVcTEyeHlucjBFck16YnhpRnd0eXNBZyJ9fQ",
+      "verifying_key_id": "test-key-alice",
+      "verification_time": "2026-06-01T00:00:00Z",
+      "expected": "valid"
+    },
+    {
+      "name": "expired-token",
+      "signed_token": {
+        "phip_capability": "1.0",
+        "token_id": "00000000-0000-4000-a000-000000000003",
+        "granted_by": "phip://acme.example/keys/test-key-alice",
+        "granted_to": "phip://acme.example/keys/test-key-alice",
+        "scope": "push_events",
+        "object_filter": "phip://acme.example/parts/*",
+        "not_before": "2026-01-15T00:00:00Z",
+        "expires": "2026-12-31T23:59:59Z",
+        "signature": {
+          "algorithm": "Ed25519",
+          "key_id": "phip://acme.example/keys/test-key-alice",
+          "value": "vW8jymqqFjgl7jsSHOey8HEPlOGbgoAgG6988hbbbPbrUHzTXfIRjoIvFivIrbNieG9TajoXmRsfL7q-B1aAAQ"
+        }
+      },
+      "transport_b64url": "eyJwaGlwX2NhcGFiaWxpdHkiOiIxLjAiLCJ0b2tlbl9pZCI6IjAwMDAwMDAwLTAwMDAtNDAwMC1hMDAwLTAwMDAwMDAwMDAwMyIsImdyYW50ZWRfYnkiOiJwaGlwOi8vYWNtZS5leGFtcGxlL2tleXMvdGVzdC1rZXktYWxpY2UiLCJncmFudGVkX3RvIjoicGhpcDovL2FjbWUuZXhhbXBsZS9rZXlzL3Rlc3Qta2V5LWFsaWNlIiwic2NvcGUiOiJwdXNoX2V2ZW50cyIsIm9iamVjdF9maWx0ZXIiOiJwaGlwOi8vYWNtZS5leGFtcGxlL3BhcnRzLyoiLCJub3RfYmVmb3JlIjoiMjAyNi0wMS0xNVQwMDowMDowMFoiLCJleHBpcmVzIjoiMjAyNi0xMi0zMVQyMzo1OTo1OVoiLCJzaWduYXR1cmUiOnsiYWxnb3JpdGhtIjoiRWQyNTUxOSIsImtleV9pZCI6InBoaXA6Ly9hY21lLmV4YW1wbGUva2V5cy90ZXN0LWtleS1hbGljZSIsInZhbHVlIjoidlc4anltcXFGamdsN2pzU0hPZXk4SEVQbE9HYmdvQWdHNjk4OGhiYmJQYnJVSHpUWGZJUmpvSXZGaXZJcmJOaWVHOVRham9YbVJzZkw3cS1CMWFBQVEifX0",
+      "verifying_key_id": "test-key-alice",
+      "verification_time": "2027-01-01T00:00:00Z",
+      "expected": "expired"
+    },
+    {
+      "name": "not-yet-valid-token",
+      "signed_token": {
+        "phip_capability": "1.0",
+        "token_id": "00000000-0000-4000-a000-000000000004",
+        "granted_by": "phip://acme.example/keys/test-key-alice",
+        "granted_to": "phip://acme.example/keys/test-key-alice",
+        "scope": "push_events",
+        "object_filter": "phip://acme.example/parts/*",
+        "not_before": "2026-01-15T00:00:00Z",
+        "expires": "2026-12-31T23:59:59Z",
+        "signature": {
+          "algorithm": "Ed25519",
+          "key_id": "phip://acme.example/keys/test-key-alice",
+          "value": "LFt3XrfSBMzjBmKONn52mKUjliniIvWYAef7UJ4j2hPgPzrCPD216CdQc3W7SNL5-_K_MmbUJNG3-93g_JUkAg"
+        }
+      },
+      "transport_b64url": "eyJwaGlwX2NhcGFiaWxpdHkiOiIxLjAiLCJ0b2tlbl9pZCI6IjAwMDAwMDAwLTAwMDAtNDAwMC1hMDAwLTAwMDAwMDAwMDAwNCIsImdyYW50ZWRfYnkiOiJwaGlwOi8vYWNtZS5leGFtcGxlL2tleXMvdGVzdC1rZXktYWxpY2UiLCJncmFudGVkX3RvIjoicGhpcDovL2FjbWUuZXhhbXBsZS9rZXlzL3Rlc3Qta2V5LWFsaWNlIiwic2NvcGUiOiJwdXNoX2V2ZW50cyIsIm9iamVjdF9maWx0ZXIiOiJwaGlwOi8vYWNtZS5leGFtcGxlL3BhcnRzLyoiLCJub3RfYmVmb3JlIjoiMjAyNi0wMS0xNVQwMDowMDowMFoiLCJleHBpcmVzIjoiMjAyNi0xMi0zMVQyMzo1OTo1OVoiLCJzaWduYXR1cmUiOnsiYWxnb3JpdGhtIjoiRWQyNTUxOSIsImtleV9pZCI6InBoaXA6Ly9hY21lLmV4YW1wbGUva2V5cy90ZXN0LWtleS1hbGljZSIsInZhbHVlIjoiTEZ0M1hyZlNCTXpqQm1LT05uNTJtS1VqbGluaUl2V1lBZWY3VUo0ajJoUGdQenJDUEQyMTZDZFFjM1c3U05MNS1fS19NbWJVSk5HMy05M2dfSlVrQWcifX0",
+      "verifying_key_id": "test-key-alice",
+      "verification_time": "2025-01-01T00:00:00Z",
+      "expected": "not_yet_valid"
+    },
+    {
+      "name": "object-filter-mismatch",
+      "signed_token": {
+        "phip_capability": "1.0",
+        "token_id": "00000000-0000-4000-a000-000000000005",
+        "granted_by": "phip://acme.example/keys/test-key-alice",
+        "granted_to": "phip://acme.example/keys/test-key-alice",
+        "scope": "push_events",
+        "object_filter": "phip://acme.example/lots/*",
+        "not_before": "2026-01-15T00:00:00Z",
+        "expires": "2026-12-31T23:59:59Z",
+        "signature": {
+          "algorithm": "Ed25519",
+          "key_id": "phip://acme.example/keys/test-key-alice",
+          "value": "6y8yZicynq38iaPHyw3h54lk9nteXv62cV_D8jLSBepXXj4IN6YKR8cAiVNw_lkdJXl1Qi1zIra6dBFw2DQ_Bw"
+        }
+      },
+      "transport_b64url": "eyJwaGlwX2NhcGFiaWxpdHkiOiIxLjAiLCJ0b2tlbl9pZCI6IjAwMDAwMDAwLTAwMDAtNDAwMC1hMDAwLTAwMDAwMDAwMDAwNSIsImdyYW50ZWRfYnkiOiJwaGlwOi8vYWNtZS5leGFtcGxlL2tleXMvdGVzdC1rZXktYWxpY2UiLCJncmFudGVkX3RvIjoicGhpcDovL2FjbWUuZXhhbXBsZS9rZXlzL3Rlc3Qta2V5LWFsaWNlIiwic2NvcGUiOiJwdXNoX2V2ZW50cyIsIm9iamVjdF9maWx0ZXIiOiJwaGlwOi8vYWNtZS5leGFtcGxlL2xvdHMvKiIsIm5vdF9iZWZvcmUiOiIyMDI2LTAxLTE1VDAwOjAwOjAwWiIsImV4cGlyZXMiOiIyMDI2LTEyLTMxVDIzOjU5OjU5WiIsInNpZ25hdHVyZSI6eyJhbGdvcml0aG0iOiJFZDI1NTE5Iiwia2V5X2lkIjoicGhpcDovL2FjbWUuZXhhbXBsZS9rZXlzL3Rlc3Qta2V5LWFsaWNlIiwidmFsdWUiOiI2eTh5WmljeW5xMzhpYVBIeXczaDU0bGs5bnRlWHY2MmNWX0Q4akxTQmVwWFhqNElONllLUjhjQWlWTndfbGtkSlhsMVFpMXpJcmE2ZEJGdzJEUV9CdyJ9fQ",
+      "verifying_key_id": "test-key-alice",
+      "verification_time": "2026-06-01T00:00:00Z",
+      "requested_object": "phip://acme.example/parts/widget-001",
+      "expected": "object_filter_mismatch"
+    },
+    {
+      "name": "forged-signature",
+      "signed_token": {
+        "phip_capability": "1.0",
+        "token_id": "00000000-0000-4000-a000-000000000006",
+        "granted_by": "phip://acme.example/keys/test-key-alice",
+        "granted_to": "phip://acme.example/keys/test-key-alice",
+        "scope": "push_events",
+        "object_filter": "phip://acme.example/parts/*",
+        "not_before": "2026-01-15T00:00:00Z",
+        "expires": "2026-12-31T23:59:59Z",
+        "signature": {
+          "algorithm": "Ed25519",
+          "key_id": "phip://acme.example/keys/test-key-alice",
+          "value": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        }
+      },
+      "transport_b64url": "eyJwaGlwX2NhcGFiaWxpdHkiOiIxLjAiLCJ0b2tlbl9pZCI6IjAwMDAwMDAwLTAwMDAtNDAwMC1hMDAwLTAwMDAwMDAwMDAwNiIsImdyYW50ZWRfYnkiOiJwaGlwOi8vYWNtZS5leGFtcGxlL2tleXMvdGVzdC1rZXktYWxpY2UiLCJncmFudGVkX3RvIjoicGhpcDovL2FjbWUuZXhhbXBsZS9rZXlzL3Rlc3Qta2V5LWFsaWNlIiwic2NvcGUiOiJwdXNoX2V2ZW50cyIsIm9iamVjdF9maWx0ZXIiOiJwaGlwOi8vYWNtZS5leGFtcGxlL3BhcnRzLyoiLCJub3RfYmVmb3JlIjoiMjAyNi0wMS0xNVQwMDowMDowMFoiLCJleHBpcmVzIjoiMjAyNi0xMi0zMVQyMzo1OTo1OVoiLCJzaWduYXR1cmUiOnsiYWxnb3JpdGhtIjoiRWQyNTUxOSIsImtleV9pZCI6InBoaXA6Ly9hY21lLmV4YW1wbGUva2V5cy90ZXN0LWtleS1hbGljZSIsInZhbHVlIjoiQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUEifX0",
+      "verifying_key_id": "test-key-alice",
+      "verification_time": "2026-06-01T00:00:00Z",
+      "expected": "invalid_signature"
+    },
+    {
+      "name": "tampered-after-signing",
+      "signed_token": {
+        "phip_capability": "1.0",
+        "token_id": "00000000-0000-4000-a000-000000000007",
+        "granted_by": "phip://acme.example/keys/test-key-alice",
+        "granted_to": "phip://acme.example/keys/test-key-alice",
+        "scope": "push_events",
+        "object_filter": "phip://acme.example/parts/*",
+        "not_before": "2026-01-15T00:00:00Z",
+        "expires": "2026-12-31T23:59:59Z",
+        "signature": {
+          "algorithm": "Ed25519",
+          "key_id": "phip://acme.example/keys/test-key-alice",
+          "value": "G6jfKvYsxw0cRfq5uDlDJkrLmu7Rfk99yLYmYOkiDMVgDCyVd3mNYUJZ5bcA6R0DTgnvMJ-YeorJzr5X0aQ4Cw"
+        }
+      },
+      "transport_b64url": "eyJwaGlwX2NhcGFiaWxpdHkiOiIxLjAiLCJ0b2tlbl9pZCI6IjAwMDAwMDAwLTAwMDAtNDAwMC1hMDAwLTAwMDAwMDAwMDAwNyIsImdyYW50ZWRfYnkiOiJwaGlwOi8vYWNtZS5leGFtcGxlL2tleXMvdGVzdC1rZXktYWxpY2UiLCJncmFudGVkX3RvIjoicGhpcDovL2FjbWUuZXhhbXBsZS9rZXlzL3Rlc3Qta2V5LWFsaWNlIiwic2NvcGUiOiJwdXNoX2V2ZW50cyIsIm9iamVjdF9maWx0ZXIiOiJwaGlwOi8vYWNtZS5leGFtcGxlL3BhcnRzLyoiLCJub3RfYmVmb3JlIjoiMjAyNi0wMS0xNVQwMDowMDowMFoiLCJleHBpcmVzIjoiMjAyNi0xMi0zMVQyMzo1OTo1OVoiLCJzaWduYXR1cmUiOnsiYWxnb3JpdGhtIjoiRWQyNTUxOSIsImtleV9pZCI6InBoaXA6Ly9hY21lLmV4YW1wbGUva2V5cy90ZXN0LWtleS1hbGljZSIsInZhbHVlIjoiRzZqZkt2WXN4dzBjUmZxNXVEbERKa3JMbXU3UmZrOTl5TFltWU9raURNVmdEQ3lWZDNtTllVSlo1YmNBNlIwRFRnbnZNSi1ZZW9ySnpyNVgwYVE0Q3cifX0",
+      "verifying_key_id": "test-key-alice",
+      "verification_time": "2026-06-01T00:00:00Z",
+      "expected": "invalid_signature"
+    },
+    {
+      "name": "read-history-token",
+      "signed_token": {
+        "phip_capability": "1.0",
+        "token_id": "00000000-0000-4000-a000-000000000008",
+        "granted_by": "phip://acme.example/keys/test-key-alice",
+        "granted_to": "phip://acme.example/keys/test-key-alice",
+        "scope": "read_history",
+        "object_filter": "phip://acme.example/parts/*",
+        "not_before": "2026-01-15T00:00:00Z",
+        "expires": "2026-12-31T23:59:59Z",
+        "signature": {
+          "algorithm": "Ed25519",
+          "key_id": "phip://acme.example/keys/test-key-alice",
+          "value": "4EmN9vMtzooV1sW9UMBY1VDAd-K2VZFa8df_F5wzj5BA0xZkJNOAZRheo9zi5sKlF0UNpxvPXJTzJGw_fiTHAg"
+        }
+      },
+      "transport_b64url": "eyJwaGlwX2NhcGFiaWxpdHkiOiIxLjAiLCJ0b2tlbl9pZCI6IjAwMDAwMDAwLTAwMDAtNDAwMC1hMDAwLTAwMDAwMDAwMDAwOCIsImdyYW50ZWRfYnkiOiJwaGlwOi8vYWNtZS5leGFtcGxlL2tleXMvdGVzdC1rZXktYWxpY2UiLCJncmFudGVkX3RvIjoicGhpcDovL2FjbWUuZXhhbXBsZS9rZXlzL3Rlc3Qta2V5LWFsaWNlIiwic2NvcGUiOiJyZWFkX2hpc3RvcnkiLCJvYmplY3RfZmlsdGVyIjoicGhpcDovL2FjbWUuZXhhbXBsZS9wYXJ0cy8qIiwibm90X2JlZm9yZSI6IjIwMjYtMDEtMTVUMDA6MDA6MDBaIiwiZXhwaXJlcyI6IjIwMjYtMTItMzFUMjM6NTk6NTlaIiwic2lnbmF0dXJlIjp7ImFsZ29yaXRobSI6IkVkMjU1MTkiLCJrZXlfaWQiOiJwaGlwOi8vYWNtZS5leGFtcGxlL2tleXMvdGVzdC1rZXktYWxpY2UiLCJ2YWx1ZSI6IjRFbU45dk10em9vVjFzVzlVTUJZMVZEQWQtSzJWWkZhOGRmX0Y1d3pqNUJBMHhaa0pOT0FaUmhlbzl6aTVzS2xGMFVOcHh2UFhKVHpKR3dfZmlUSEFnIn19",
+      "verifying_key_id": "test-key-alice",
+      "verification_time": "2026-06-01T00:00:00Z",
+      "requested_scope": "read_state",
+      "expected": "valid"
+    },
+    {
+      "name": "foreign-signer-token",
+      "signed_token": {
+        "phip_capability": "1.0",
+        "token_id": "00000000-0000-4000-a000-000000000009",
+        "granted_by": "phip://acme.example/keys/test-key-alice",
+        "granted_to": "phip://acme.example/keys/test-key-alice",
+        "scope": "push_events",
+        "object_filter": "phip://acme.example/parts/*",
+        "not_before": "2026-01-15T00:00:00Z",
+        "expires": "2026-12-31T23:59:59Z",
+        "signature": {
+          "algorithm": "Ed25519",
+          "key_id": "phip://other.example/keys/test-key-bob",
+          "value": "UQwLi0Ipkt9YfelXUfGT-z0ng33mHdB542BtAx9a19WXObkMmMeVBsiXas2AlYMgImEUj5oO_Iso8j28_jstBg"
+        }
+      },
+      "transport_b64url": "eyJwaGlwX2NhcGFiaWxpdHkiOiIxLjAiLCJ0b2tlbl9pZCI6IjAwMDAwMDAwLTAwMDAtNDAwMC1hMDAwLTAwMDAwMDAwMDAwOSIsImdyYW50ZWRfYnkiOiJwaGlwOi8vYWNtZS5leGFtcGxlL2tleXMvdGVzdC1rZXktYWxpY2UiLCJncmFudGVkX3RvIjoicGhpcDovL2FjbWUuZXhhbXBsZS9rZXlzL3Rlc3Qta2V5LWFsaWNlIiwic2NvcGUiOiJwdXNoX2V2ZW50cyIsIm9iamVjdF9maWx0ZXIiOiJwaGlwOi8vYWNtZS5leGFtcGxlL3BhcnRzLyoiLCJub3RfYmVmb3JlIjoiMjAyNi0wMS0xNVQwMDowMDowMFoiLCJleHBpcmVzIjoiMjAyNi0xMi0zMVQyMzo1OTo1OVoiLCJzaWduYXR1cmUiOnsiYWxnb3JpdGhtIjoiRWQyNTUxOSIsImtleV9pZCI6InBoaXA6Ly9vdGhlci5leGFtcGxlL2tleXMvdGVzdC1rZXktYm9iIiwidmFsdWUiOiJVUXdMaTBJcGt0OVlmZWxYVWZHVC16MG5nMzNtSGRCNTQyQnRBeDlhMTlXWE9ia01tTWVWQnNpWGFzMkFsWU1nSW1FVWo1b09fSXNvOGoyOF9qc3RCZyJ9fQ",
+      "verifying_key_id": "test-key-bob",
+      "verification_time": "2026-06-01T00:00:00Z",
+      "expected": "valid",
+      "notes": "Intra-authority resolvers without federation MUST reject as INVALID_CAPABILITY. Federated resolvers fetch test-key-bob's actor and verify; result is valid."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Two weeks of base-repo work that **unblocks the next round of client libraries** (`phip-py`, `phip-rs`, `phip-js`) and prevents each lib from independently reinventing wheels. Eight discrete deliverables; all share the same goal: lock down the wire contract and operator-facing tooling so independent implementations can land without spec drift.

## What's in the PR

### Four new JSON Schemas

Spec text already defined these formats; now they're machine-readable:

| Schema | What it validates |
|---|---|
| `schemas/capability-token.json` | Capability token shape from §11.3.1 |
| `schemas/meta.json` | `/meta` document from §12.7 |
| `schemas/authority-transfer-payload.json` | Event payload from §4.6.2 |
| `schemas/bundle-manifest.json` | Bundle manifest from §4.3.4 |

Each spec section now has a one-line pointer to its schema. All four compile cleanly with ajv 2020.

### Two new test vector groups

| Vectors | Cases | Self-check |
|---|---|---|
| `tests/vectors/token/cases.json` | 9 (valid push/read, expired, not-yet-valid, object_filter mismatch, forged sig, post-signing tamper, read-history coverage, foreign-signer) | +20 assertions |
| `tests/vectors/bundle/cases.json` | 3 (one-object snapshot, multi-object snapshot, tampered-event rejection) | +9 assertions |

Vector self-check is now **189/189** (was 160).

### Three new spec sections

| Section | Why |
|---|---|
| §11.6 Caller Authentication | Defines mTLS (§11.6.1) and signed HTTP requests per RFC 9421 (§11.6.2). Closes the bearer-token gap that made §11.5.2 step-7 tautological |
| §12.2.2 Cursor Stability | Cursors MUST survive resolver restart and replica swap; expired cursors surface as `INVALID_QUERY` |
| §12.3.2 General Retry Guidance | Per-status retry semantics, exponential-backoff defaults, idempotency-on-`event_id` for safe POST retries |

### Three repo-level docs

- `VERSIONING.md` — spec MAJOR/MINOR/PATCH rules, library-tracks-spec pinning, schema independence
- `CONTRIBUTING.md` — PR checklist, scope rules, reference-vs-server boundary
- `IMPLEMENTATIONS.md` — registry of known PhIP implementations

### `@phip/conformance` package

`tests/conformance/` is now a publishable npm package (`bin: phip-conformance`). Self-contained — embeds the test keypair so it installs globally without dragging the wider repo:

```
npm install -g @phip/conformance
phip-conformance http://my-resolver.example --authority my-authority.example
```

The package's `run.js` doubles as the in-tree test (parent `tests/package.json`'s `npm run conformance` still works).

### Conformance §20 federation mechanics (opt-in)

When `/meta` advertises `delegations` or `successor`, the suite probes the redirect machinery (Location, PhIP-Delegation, PhIP-Transfer-Event headers). Skipped silently otherwise.

Full two-server federation conformance (cross-authority token verification, redirect-chain following, mirror serving) is documented as out-of-scope for the single-URL probe; reference test scenarios at `reference/test/federation.js` are available for per-implementation porting.

## Verification

| Test | Before | After |
|---|---|---|
| Reference smoke + federation | ALL PASS | ALL PASS |
| Vector self-check | 160 | **189** (+29) |
| HTTP conformance vs reference (no fed config) | 76/76 | 76/76 |
| HTTP conformance vs reference (delegations + successor) | n/a | **82/82** |
| Schemas compile clean | 7/7 | 11/11 |

## What this unblocks

After this lands, `phip-py` and `phip-rs` (and eventually `phip-js`) can be built without:
- Reinventing token validation (use `schemas/capability-token.json`)
- Diverging on retry policy (follow §12.3.2)
- Mismatching cursor expectations (follow §12.2.2)
- Implementing signed requests differently or not at all (follow §11.6)
- Independently implementing bundle verification (use `tests/vectors/bundle/`)

And third-party resolver authors can prove conformance without the repo:

```
npm install -g @phip/conformance
phip-conformance https://their-server.example
```

## Test plan

- [x] All four new schemas compile with ajv
- [x] Vector self-check passes (189/189)
- [x] Reference smoke + federation pass
- [x] HTTP conformance passes against reference (76/76)
- [x] HTTP conformance §20 fires correctly when reference has delegations + successor (82/82)
- [x] `@phip/conformance` runs standalone after `npm install` in its directory
- [ ] Reviewer: spot-check §11.6 RFC 9421 profile — particularly the `PhIP-Actor` header binding (line 11.6.2 step 5) which leaves the key→actor binding to operator policy
- [ ] Reviewer: confirm `schemas/meta.json` doesn't exclude any field that `phip-server` advertises (compare against `reference/src/server.js` `buildMeta`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)