### PR TITLE
spec: A42 — optional topology disclosure (read_topology scope)

### DIFF
--- a/schemas/capability-token.json
+++ b/schemas/capability-token.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/mfgs-us/phip/schemas/capability-token.json",
-  "version": "1.0",
+  "version": "1.1",
   "title": "PhIP Capability Token",
   "description": "Schema for the PhIP capability token format defined in Section 11.3. Tokens are JSON objects, base64url-encoded for transport in the `Authorization: PhIP-Capability <token>` header. Cryptographic verification (signature, key resolution, scope/filter/expiry checks) is enforced by resolvers per Section 11.3.4 and is outside the scope of this schema.",
 
@@ -46,9 +46,10 @@
         "push_relations",
         "read_state",
         "read_history",
+        "read_topology",
         "read_query"
       ],
-      "description": "Permission level granted by this token. A single token has exactly one scope; combining scopes requires issuing multiple tokens. See Section 11.3.2."
+      "description": "Permission level granted by this token. A single token has exactly one scope; combining scopes requires issuing multiple tokens. See Section 11.3.2. `read_topology` grants access to chain topology only (event IDs, types, timestamps, previous_hash links — no payloads or actors); see Section 11.5.6."
     },
     "object_filter": {
       "type": "string",

--- a/schemas/capability-token.json
+++ b/schemas/capability-token.json
@@ -34,8 +34,11 @@
       "description": "PhIP URI of the actor who issued the token. MUST resolve to an `actor` object in the granting authority's namespace. Per §11.2, key resources are themselves actors, so a key URI like `phip://acme.example/keys/ops-2026` is a valid grantor."
     },
     "granted_to": {
-      "$ref": "#/$defs/phipUri",
-      "description": "PhIP URI of the actor authorized to use this token. The resolver compares against the requesting actor (when externally authenticated)."
+      "oneOf": [
+        { "$ref": "#/$defs/phipUri" },
+        { "type": "string", "const": "*" }
+      ],
+      "description": "PhIP URI of the actor authorized to use this token, OR the literal string '*' to grant the token to any presenter. '*' disables the §11.5.2 step-7 `granted_to` actor match. Issuers SHOULD restrict '*' tokens to non-write, low-leakage scopes (notably `read_topology`); issuing a `read_history` or write-scoped token with `granted_to: \"*\"` is equivalent to publishing the resource and SHOULD be rejected at policy-review time."
     },
     "scope": {
       "type": "string",

--- a/schemas/meta.json
+++ b/schemas/meta.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://github.com/mfgs-us/phip/schemas/meta.json",
-  "version": "1.0",
+  "version": "1.1",
   "title": "PhIP Resolver Metadata Document",
   "description": "Schema for the resolver metadata document at /.well-known/phip/meta defined in Section 12.7. This document describes the resolver's protocol version, supported operations, conformance class, and federation state (root key, delegations, successor, mirror URLs).",
 
@@ -41,6 +41,15 @@
       "type": "object",
       "description": "Optional map describing supported filter operators, glob syntax, sort orders. Schema is open-ended.",
       "additionalProperties": true
+    },
+    "disclosures": {
+      "type": "array",
+      "description": "Optional disclosure modes this resolver honors on GET history beyond the default full-history response. Currently only 'topology' is defined (Section 11.5.6). Absence implies no disclosure modes are supported; clients SHOULD NOT probe for them.",
+      "items": {
+        "type": "string",
+        "enum": ["topology"]
+      },
+      "uniqueItems": true
     },
     "root_key": {
       "$ref": "#/$defs/phipUri",

--- a/schemas/topology-response.json
+++ b/schemas/topology-response.json
@@ -31,13 +31,13 @@
 
     "topology": {
       "type": "array",
-      "description": "Ordered slice of the object's event chain shape. Order matches the request's `order` parameter (default ascending). MAY be empty for a newly created object resolved before its first event lands.",
+      "description": "Slice of the object's event chain shape, always in ascending chain order (oldest first; genesis at index 0 on the first page). The request's `?order` parameter is ignored in topology mode — see Section 11.5.6.5. MAY be empty when a paginated request returns no entries on the current page (e.g., a cursor past the end of the chain).",
       "items": { "$ref": "#/$defs/topologyEntry" }
     },
 
     "topology_signature": {
       "$ref": "#/$defs/topologySignature",
-      "description": "Ed25519 signature, by a resolver authority key, over the JCS canonicalization of the OBJECT { phip_id, page_length, disclosure, topology } — the entire envelope minus the signature itself. Attests resolver-observed shape at response time; does NOT attest end-to-end chain integrity (that requires `read_history`)."
+      "description": "Ed25519 signature, by a resolver authority key, over the JCS canonicalization of the OBJECT { phip_id, page_length, disclosure, topology } — the four canonical fields per Section 11.5.6.4. Any other top-level fields the resolver emits (e.g., served_at, debug hints) are NOT covered by the signature; verifiers MUST ignore them when reconstructing signed bytes. Attests resolver-observed shape at response time; does NOT attest end-to-end chain integrity (that requires `read_history`)."
     },
 
     "next_cursor": {

--- a/schemas/topology-response.json
+++ b/schemas/topology-response.json
@@ -1,0 +1,127 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/mfgs-us/phip/schemas/topology-response.json",
+  "version": "1.0",
+  "title": "PhIP Topology Disclosure Response",
+  "description": "Schema for the response body returned by GET /.well-known/phip/history/{namespace}/{local-id}?disclosure=topology when the resolver supports topology disclosure (Section 11.5.6). Topology mode exposes chain shape (event IDs, types, timestamps, and per-event hash links) without payloads, actors, or per-event signatures, so an authority can publicly attest that a restricted object exists and has been modified along a particular chain without revealing its contents.",
+
+  "type": "object",
+  "required": [
+    "phip_id",
+    "page_length",
+    "disclosure",
+    "topology",
+    "topology_signature"
+  ],
+  "additionalProperties": true,
+  "properties": {
+    "phip_id": { "$ref": "#/$defs/phipUri" },
+
+    "page_length": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Number of entries in this `topology` page. NOT the total chain length — exposing total length would leak fingerprinting bits (Section 11.5.6.7). Clients walking a paginated topology MUST count their own running total across pages."
+    },
+
+    "disclosure": {
+      "type": "string",
+      "const": "topology",
+      "description": "Marker confirming this is a topology disclosure response, not a full-history response."
+    },
+
+    "topology": {
+      "type": "array",
+      "description": "Ordered slice of the object's event chain shape. Order matches the request's `order` parameter (default ascending). MAY be empty for a newly created object resolved before its first event lands.",
+      "items": { "$ref": "#/$defs/topologyEntry" }
+    },
+
+    "topology_signature": {
+      "$ref": "#/$defs/topologySignature",
+      "description": "Ed25519 signature, by a resolver authority key, over the JCS canonicalization of the OBJECT { phip_id, page_length, disclosure, topology } — the entire envelope minus the signature itself. Attests resolver-observed shape at response time; does NOT attest end-to-end chain integrity (that requires `read_history`)."
+    },
+
+    "next_cursor": {
+      "oneOf": [
+        { "type": "null" },
+        { "type": "string", "minLength": 1 }
+      ],
+      "description": "Pagination cursor for the next page, or null when no more events. Cursor semantics match Section 12.2.2."
+    }
+  },
+
+  "$defs": {
+    "phipUri": {
+      "type": "string",
+      "pattern": "^phip://[A-Za-z0-9.-]+/[A-Za-z0-9._~%-]+(?:/[A-Za-z0-9._~%-]+)+$"
+    },
+
+    "topologyEntry": {
+      "type": "object",
+      "required": ["event_id", "type", "timestamp", "previous_hash", "event_hash"],
+      "additionalProperties": false,
+      "properties": {
+        "event_id": {
+          "type": "string",
+          "pattern": "^([A-Za-z][A-Za-z0-9_-]*-)?[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$",
+          "description": "Verbatim event_id from the underlying full event."
+        },
+        "type": {
+          "oneOf": [
+            { "$ref": "#/$defs/coreEventType" },
+            { "type": "string", "const": "redacted" }
+          ],
+          "description": "Verbatim event type from the underlying full event, OR the literal string 'redacted' if the authority considers the type itself sensitive (Section 11.5.6.3)."
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time",
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d+)?(Z|[+\\-]\\d{2}:\\d{2})$"
+        },
+        "previous_hash": {
+          "oneOf": [
+            { "type": "string", "const": "genesis" },
+            { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" }
+          ],
+          "description": "Verbatim `previous_hash` from the underlying full event. For entry N>0 in a fully-disclosed chain, MUST equal `event_hash` of entry N-1 — this is what makes the topology chain-verifiable."
+        },
+        "event_hash": {
+          "type": "string",
+          "pattern": "^sha256:[0-9a-f]{64}$",
+          "description": "SHA-256 of the JCS canonicalization of the full underlying event (the same value that would appear as `previous_hash` on the next event). Lets topology-only consumers walk the chain without having the full event payloads."
+        }
+      }
+    },
+
+    "coreEventType": {
+      "type": "string",
+      "enum": [
+        "created",
+        "state_transition",
+        "attribute_update",
+        "relation_added",
+        "relation_removed",
+        "software_update",
+        "measurement",
+        "process",
+        "lot_split",
+        "lot_merge",
+        "note",
+        "authority_transfer"
+      ]
+    },
+
+    "topologySignature": {
+      "type": "object",
+      "required": ["algorithm", "key_id", "value"],
+      "additionalProperties": false,
+      "properties": {
+        "algorithm": { "type": "string", "const": "Ed25519" },
+        "key_id": { "$ref": "#/$defs/phipUri" },
+        "value": {
+          "type": "string",
+          "pattern": "^(base64url:)?[A-Za-z0-9_\\-]+={0,2}$"
+        }
+      }
+    }
+  }
+}

--- a/spec/CHANGELOG.md
+++ b/spec/CHANGELOG.md
@@ -52,6 +52,17 @@ All notable changes to the PhIP specification will be documented in this file.
   alternative).
 - `schemas/meta.json` → 1.1: adds optional `disclosures` field.
 
+### Order normative (topology mode only)
+
+Topology disclosure MUST return events in **ascending chain order**
+(genesis at index 0 of the first page). The `?order` query parameter
+from §12.2.1 is ignored under `?disclosure=topology`; resolvers MUST
+NOT honor `?order=desc` for a topology request. This is a hard
+requirement so the §11.5.6.4 chain-walk rule
+(`entry[N].previous_hash == entry[N-1].event_hash`) applies uniformly
+across implementations. Full GET history continues to honor `?order`
+unchanged.
+
 ### Design notes
 
 Topology signature covers the JCS canonicalization of the response

--- a/spec/CHANGELOG.md
+++ b/spec/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 All notable changes to the PhIP specification will be documented in this file.
 
+## [Unreleased]
+
+### Added
+- New §11.5.6 Topology Disclosure (optional): a middle ground between
+  `read_state` (current projection only) and `read_history` (full event
+  payloads). Resolvers MAY honor `?disclosure=topology` on GET history
+  to return event IDs, types, timestamps, and `previous_hash` links —
+  enough to attest that an object exists and has been modified along a
+  particular chain shape, without revealing payloads, actors, or
+  per-event signatures. The whole topology array is signed once by the
+  resolver's authority key.
+- New `read_topology` capability-token scope (§11.3.2,
+  `schemas/capability-token.json` bumped to 1.1).
+- §11.5.2 resolution order updated to route `read_topology` tokens
+  through topology mode.
+- Appendix A.2 entry A42 (Medium): selective history disclosure.
+
+Motivation: enables the "private design with publicly listed instances"
+composition pattern. An external party resolving a public `assembly`
+that `instance_of`s a private `design` can confirm the design exists
+and is under active stewardship without seeing its payloads, by
+presenting a `read_topology` token published alongside the authority
+record.
+
+Surfaced while implementing a read-only PhIP resolver in the
+[asap-pcb-dfm](https://github.com/vmc-7645/asap-pcb-dfm) pilot. See
+PR-link-here for proposal text, schema update, and Appendix A entry.
+
 ## [0.1.0-draft] — 2026-04-09
 
 ### Added

--- a/spec/CHANGELOG.md
+++ b/spec/CHANGELOG.md
@@ -32,6 +32,17 @@ All notable changes to the PhIP specification will be documented in this file.
   `?disclosure=topology` as a scope mismatch (403). Step 7 skips the
   `granted_to` actor match when `granted_to == "*"`.
 - **Appendix A.2 entry A42 (Medium)** — first post-v0.1 open item.
+- **Test vectors** at `tests/vectors/topology/cases.json` — five cases
+  (valid-multi-event, valid-single-event, tampered-envelope,
+  tampered-chain-link, two-pages-stitchable) covering signature
+  verification, the chain-walk rule, and inter-page link semantics.
+  Self-check gains 10 assertions (189 → 199).
+- **Conformance §21** in `tests/conformance/run.js` — opt-in probe that
+  skips when `/meta.disclosures` lacks `"topology"`. When advertised,
+  exercises the `?disclosure=topology` endpoint, verifies envelope
+  shape, ascending order (including `?order=desc` ignored), chain
+  walk, Cache-Control: no-store, and signature verification against
+  the resolver's resolved signing key.
 
 ### Changed
 

--- a/spec/CHANGELOG.md
+++ b/spec/CHANGELOG.md
@@ -52,6 +52,20 @@ entry[N-1].event_hash`) without holding the full event payloads.
 `page_length` (not total `history_length`) is reported to avoid
 giving every reader a stable count fingerprint.
 
+Error code mapping for the new failure modes (mapped to §12.6
+existing codes — no new codes introduced):
+- Resolver doesn't advertise topology, but a `read_topology` token
+  is presented → `OPERATION_NOT_SUPPORTED` (405).
+- `read_topology` token presented to GET history WITHOUT
+  `disclosure=topology` → `INVALID_CAPABILITY` (403,
+  "scope insufficient").
+- Token defects (malformed, expired, forged signature) remain
+  `INVALID_CAPABILITY` (403) as in §11.3.4 / §11.5.2.
+
+Cache-Control: topology responses MUST be `no-store` (or
+`private, max-age=0`) — the `topology_signature` is fresh per
+response and a cached topology can't be trusted.
+
 Motivation: enables the "private design with publicly listed
 instances" composition pattern. Surfaced while implementing a
 read-only PhIP resolver in the

--- a/spec/CHANGELOG.md
+++ b/spec/CHANGELOG.md
@@ -4,31 +4,60 @@ All notable changes to the PhIP specification will be documented in this file.
 
 ## [Unreleased]
 
-### Added
-- New §11.5.6 Topology Disclosure (optional): a middle ground between
-  `read_state` (current projection only) and `read_history` (full event
-  payloads). Resolvers MAY honor `?disclosure=topology` on GET history
-  to return event IDs, types, timestamps, and `previous_hash` links —
-  enough to attest that an object exists and has been modified along a
-  particular chain shape, without revealing payloads, actors, or
-  per-event signatures. The whole topology array is signed once by the
-  resolver's authority key.
-- New `read_topology` capability-token scope (§11.3.2,
-  `schemas/capability-token.json` bumped to 1.1).
-- §11.5.2 resolution order updated to route `read_topology` tokens
-  through topology mode.
-- Appendix A.2 entry A42 (Medium): selective history disclosure.
+### Added — A42 selective history disclosure
 
-Motivation: enables the "private design with publicly listed instances"
-composition pattern. An external party resolving a public `assembly`
-that `instance_of`s a private `design` can confirm the design exists
-and is under active stewardship without seeing its payloads, by
-presenting a `read_topology` token published alongside the authority
-record.
+- **New §11.5.6 Topology Disclosure (optional)** — a middle ground
+  between `read_state` (current projection only) and `read_history`
+  (full event payloads). Resolvers MAY honor `?disclosure=topology` on
+  GET history to return event IDs, types, timestamps, `previous_hash`
+  links, and `event_hash` per entry — enough to attest "this object
+  exists, has chain shape X, was last touched at T" and to verify
+  chain continuity from the response alone, without revealing
+  payloads, actors, or per-event signatures.
+- **New `read_topology` capability-token scope** (§11.3.2). Grants
+  ONLY topology disclosure mode — not GET state, default GET history,
+  QUERY, or any PUSH.
+- **`granted_to` accepts the literal string `"*"`** (§11.3.1) — a
+  presenter-anonymous grant that disables the §11.5.2 step-7 actor
+  match. Intended for low-leakage scopes (notably `read_topology`)
+  and SHOULD NOT be combined with `read_history`, `read_query`, or
+  push scopes.
+- **`/meta.disclosures`** array advertises which disclosure modes the
+  resolver supports (§12.7). Only `"topology"` is defined in v0.1.
+- **`schemas/topology-response.json`** defines the response document
+  (`phip_id`, `page_length`, `disclosure`, `topology`,
+  `topology_signature`, `next_cursor`).
+- **§11.5.2 resolution order** updated to route `read_topology`
+  tokens through topology mode and to treat `read_topology` without
+  `?disclosure=topology` as a scope mismatch (403). Step 7 skips the
+  `granted_to` actor match when `granted_to == "*"`.
+- **Appendix A.2 entry A42 (Medium)** — first post-v0.1 open item.
 
-Surfaced while implementing a read-only PhIP resolver in the
+### Changed
+
+- `schemas/capability-token.json` → 1.1: `scope` enum gains
+  `read_topology`; `granted_to` is now `oneOf [phipUri, "*"]`. MINOR
+  bump per VERSIONING.md (additive enum value, additive type
+  alternative).
+- `schemas/meta.json` → 1.1: adds optional `disclosures` field.
+
+### Design notes
+
+Topology signature covers the JCS canonicalization of the response
+envelope `{ phip_id, page_length, disclosure, topology }` — not just
+the `topology` array — to bind the array to the object it describes
+and prevent re-attribution attacks. Each entry carries `event_hash`
+so consumers can verify chain continuity (`entry[N].previous_hash ==
+entry[N-1].event_hash`) without holding the full event payloads.
+`page_length` (not total `history_length`) is reported to avoid
+giving every reader a stable count fingerprint.
+
+Motivation: enables the "private design with publicly listed
+instances" composition pattern. Surfaced while implementing a
+read-only PhIP resolver in the
 [asap-pcb-dfm](https://github.com/vmc-7645/asap-pcb-dfm) pilot. See
-PR-link-here for proposal text, schema update, and Appendix A entry.
+[mfgs-us/phip#10](https://github.com/mfgs-us/phip/pull/10) for the
+draft PR.
 
 ## [0.1.0-draft] — 2026-04-09
 

--- a/spec/phip-core.md
+++ b/spec/phip-core.md
@@ -1916,6 +1916,7 @@ any object whose `phip_id` starts with that prefix.
 | `push_relations` | Append `relation_added` and `relation_removed` events only |
 | `read_state` | Read object projection via GET (no history) |
 | `read_history` | Read object projection AND full event history |
+| `read_topology` | Read chain topology (event IDs, types, timestamps, `previous_hash` links) of an object's history, without payloads, actors, or per-event signatures. See §11.5.6 |
 | `read_query` | Match objects via QUERY |
 
 A token with `push_events` scope is a broad grant. The narrower scopes 
@@ -2174,7 +2175,9 @@ order:
    11.3.4 steps 1–4.
 5. Verify the token's `scope` covers the requested operation:
    - GET requires `read_state` or `read_history`
-   - GET history requires `read_history`
+   - GET history requires `read_history`, OR `read_topology` if the
+     resolver supports topology disclosure (§11.5.6) and the caller has
+     explicitly requested topology mode
    - QUERY requires `read_query`
 6. Verify the token's `object_filter` matches the target `phip_id`. For 
    QUERY, the filter restricts which objects can be returned in the 
@@ -2216,6 +2219,147 @@ discovery for regulatory disclosures, safety certifications, and
 provenance claims that are intended to be verifiable by any party. 
 Authorities that hold commercially sensitive data MUST attach 
 `phip:access` explicitly — silence is consent.
+
+#### 11.5.6 Topology Disclosure (Optional)
+
+`read_state` exposes the current projection, `read_history` exposes every
+event in full. There is a real gap between them: an authority may want to
+publish that an object exists, has a chain of N events, and was last
+modified at time T, *without* revealing the contents of those events. The
+canonical use case is a private design with publicly listed instances —
+the instance object holds a public `instance_of` relation pointing at the
+design, and external parties want to confirm the design exists and is
+under active stewardship without seeing its payloads.
+
+The `read_topology` scope (§11.3.2) and this subsection define an
+optional disclosure mode that fills this gap.
+
+##### 11.5.6.1 Scope and Limits
+
+Topology disclosure is OPTIONAL. A resolver advertises support by
+including `read_topology` in the scopes it issues tokens for; absence
+implies no support. A resolver that does not implement topology mode
+MUST reject `read_topology` tokens with `INVALID_CAPABILITY` (403).
+
+Topology mode is read-only and applies only to GET history requests
+(§12.2.1). It does not apply to GET state, QUERY, or any PUSH operation.
+
+##### 11.5.6.2 Requesting Topology
+
+A caller holding a `read_topology` token requests topology mode by
+appending `?disclosure=topology` to the GET history URL:
+
+```
+GET https://{authority}/.well-known/phip/history/{namespace}/{local-id}
+    ?disclosure=topology
+Authorization: PhIP-Capability <token>
+```
+
+A caller holding `read_history` MAY also request `disclosure=topology`,
+in which case the resolver MUST honor it and return the topology shape.
+This lets clients that don't need payload contents reduce bandwidth.
+
+Absent the `disclosure` parameter, the resolver returns the full history
+form (§12.2.1) when the caller's scope permits.
+
+##### 11.5.6.3 Topology Response Shape
+
+```json
+{
+  "phip_id": "phip://acme.example/projects/widget-v3",
+  "history_length": 12,
+  "disclosure": "topology",
+  "topology": [
+    {
+      "event_id": "evt-...",
+      "type": "created",
+      "timestamp": "2026-01-15T09:00:00Z",
+      "previous_hash": "genesis"
+    },
+    {
+      "event_id": "evt-...",
+      "type": "attribute_update",
+      "timestamp": "2026-01-22T14:30:00Z",
+      "previous_hash": "sha256:..."
+    }
+  ],
+  "topology_signature": {
+    "algorithm": "Ed25519",
+    "key_id": "phip://acme.example/keys/resolver-2026",
+    "value": "base64url:..."
+  },
+  "next_cursor": null
+}
+```
+
+Each topology entry MUST contain exactly these four fields:
+
+| Field | Source |
+|---|---|
+| `event_id` | Verbatim from the underlying full event |
+| `type` | Verbatim event type. An authority MAY substitute the literal string `"redacted"` if the type itself is sensitive |
+| `timestamp` | Verbatim from the underlying full event |
+| `previous_hash` | Verbatim from the underlying full event |
+
+The `payload`, `actor`, and per-event `signature` fields MUST NOT appear
+in topology mode.
+
+##### 11.5.6.4 Topology Signature
+
+The `topology_signature` covers the JCS canonicalization of the
+`topology` array. The `key_id` MUST be a key resource (§11.2) of the
+authority serving the resolver. Verification:
+
+1. Resolve `key_id` to the public key (§11.2).
+2. JCS-encode the `topology` array verbatim.
+3. Verify the Ed25519 signature against those bytes.
+
+The topology signature attests that the resolver, acting for the
+authority, observed a chain with exactly this shape at the time of the
+response. It does NOT attest to chain integrity end-to-end — that
+requires `read_history` and per-event signature verification.
+
+A resolver MUST sign the topology fresh for each response; topology
+signatures MUST NOT be cached across calls, because pagination cursors
+and `not_before`/`expires` windows may change the visible slice.
+
+##### 11.5.6.5 Pagination
+
+Topology mode honors the same `limit` and `cursor` parameters as full
+history (§12.2.1). The `topology_signature` covers only the events in
+the current page; consumers stitching paginated topology MUST verify
+each page's signature independently.
+
+##### 11.5.6.6 Cross-Authority Composition
+
+Topology mode is the recommended way to publicly attest that a
+restricted object exists without exposing its contents. The typical
+composition:
+
+- A `design` object at `phip://acme.example/projects/widget-v3` has
+  `phip:access.policy = capability`.
+- The authority pre-issues a long-lived `read_topology` token granted
+  to the wildcard actor `phip://*/actor/*` (no `granted_to` restriction
+  beyond presence of the token) and publishes the token alongside the
+  authority record.
+- An `assembly` object instance of that design is public; downstream
+  readers resolving the assembly can follow the `instance_of` relation
+  to the design URI, present the public topology token, and confirm
+  the design's lifecycle shape without seeing payloads.
+
+Authorities that do not wish to publicly attest topology can simply not
+issue `read_topology` tokens for the restricted object; the existing
+`ACCESS_DENIED` (403) behavior is unchanged.
+
+##### 11.5.6.7 What Topology Does Not Protect
+
+Topology mode is selective disclosure, not anonymization:
+
+- Event count, event types, and timestamps are revealed. Inference
+  from those alone may be material — e.g., a burst of measurement
+  events at hour H may correlate with a known production incident.
+- Authorities that consider timing or event-type cadence sensitive
+  SHOULD NOT issue `read_topology` tokens for those objects.
 
 ### 11.6 Caller Authentication
 
@@ -3402,8 +3546,9 @@ Issues identified through scenario stress-testing and systematic review.
 
 ### A.2 Open Issues — Post-v0.1
 
-All issues identified through v0.1 stress-testing are resolved. Future 
-revisions will add issues as they surface.
+| # | Issue | Severity | Notes |
+|---|---|---|---|
+| A42 | Selective history disclosure | Medium | `read_state` and `read_history` are the only read scopes on history. There is no middle ground for "this object exists, has chain shape X, was last touched at T" without exposing payloads. Surfaces in the "private design with publicly listed instances" pattern: a public `assembly` `instance_of` a private `design`; downstream readers want to confirm the design's chain shape without seeing its contents. Proposed: optional topology disclosure mode (§11.5.6) with new `read_topology` scope. |
 
 ---
 

--- a/spec/phip-core.md
+++ b/spec/phip-core.md
@@ -2146,7 +2146,7 @@ The `phip:access` attribute namespace defines the following fields:
 | Policy | Meaning |
 |---|---|
 | `public` | Anyone may GET, read history, and match in QUERY. Default if `phip:access` is absent. |
-| `authenticated` | Caller MUST present a valid capability token with any `read_*` scope, regardless of `granted_to` |
+| `authenticated` | Caller MUST present a valid capability token with any `read_*` scope appropriate to the requested operation (§11.5.2 step 5), regardless of `granted_to` |
 | `capability` | Caller MUST present a capability token whose `granted_to` matches the requesting actor and whose scope covers the requested operation |
 | `private` | No external reads. Only the authority itself may read. |
 
@@ -2173,20 +2173,22 @@ order:
    `MISSING_CAPABILITY` (403).
 4. Verify the token signature, expiry, and `granted_to` per Section 
    11.3.4 steps 1–4.
-5. Verify the token's `scope` covers the requested operation:
-   - If `scope == "read_topology"`: (a) if the resolver does not
-     advertise topology disclosure in `/meta.disclosures` (§12.7),
-     reject with `OPERATION_NOT_SUPPORTED` (405) — the token is
-     structurally valid but the resolver cannot honor it; (b)
-     otherwise, the token covers GET history only when the request
-     URL contains `disclosure=topology`. A `read_topology` token
-     presented WITHOUT that query parameter is treated as
-     scope-insufficient and rejected with `INVALID_CAPABILITY`
-     (403).
-   - GET requires `read_state` or `read_history`
-   - GET history requires `read_history` for the default response,
-     OR `read_topology` per the substep above
-   - QUERY requires `read_query`
+5. Verify the token's `scope` covers the requested operation. The
+   mapping is:
+
+   | Operation | Token scope that covers it |
+   |---|---|
+   | GET (state) | `read_state` or `read_history` |
+   | GET history (default response) | `read_history` |
+   | GET history with `?disclosure=topology` | `read_history` or `read_topology` (the latter requires the resolver to advertise topology in `/meta.disclosures`; otherwise return `OPERATION_NOT_SUPPORTED` (405) — see §11.5.6.1) |
+   | QUERY | `read_query` |
+
+   A presented scope that does not appear in the matching row is
+   scope-insufficient and MUST be rejected with `INVALID_CAPABILITY`
+   (403). In particular, a `read_topology` token presented to any
+   operation other than GET history with `?disclosure=topology` is
+   scope-insufficient.
+
 6. Verify the token's `object_filter` matches the target `phip_id`. For 
    QUERY, the filter restricts which objects can be returned in the 
    match list — objects outside the filter MUST be silently omitted, 
@@ -2195,8 +2197,11 @@ order:
    `granted_to`. When `granted_to` is the literal string `"*"`, this 
    check is skipped (§11.3.1) — the token grants any presenter.
 
-If any check fails, return `ACCESS_DENIED` (403) for policy mismatches 
-or `INVALID_CAPABILITY` (403) for token defects.
+If any check fails, return `ACCESS_DENIED` (403) for policy mismatches,
+`INVALID_CAPABILITY` (403) for token defects (including scope
+insufficiency), or `OPERATION_NOT_SUPPORTED` (405) when the resolver
+does not implement a requested optional feature (currently: topology
+disclosure under §11.5.6).
 
 #### 11.5.3 QUERY Filtering
 
@@ -2252,9 +2257,10 @@ Topology disclosure is OPTIONAL. A resolver advertises support by
 including `"topology"` in the `disclosures` array of its `/meta`
 document (§12.7). Resolvers that do not advertise topology support
 MUST reject `read_topology` tokens with `OPERATION_NOT_SUPPORTED`
-(405) per §11.5.2 step 5(a) — the token is structurally valid but
-the resolver cannot honor it. Clients SHOULD check `/meta` before
-presenting a `read_topology` token rather than probing.
+(405) per the §11.5.2 step 5 scope table — the token is
+structurally valid but the resolver cannot honor it. Clients SHOULD
+check `/meta` before presenting a `read_topology` token rather than
+probing.
 
 The `read_topology` scope grants **only** the topology disclosure
 mode described in this subsection. It does NOT authorize GET state,
@@ -2276,16 +2282,22 @@ Authorization: PhIP-Capability <token>
 ```
 
 A caller holding `read_history` MAY also include
-`disclosure=topology`, in which case the resolver MUST honor it and
-return the topology shape. This lets clients that don't need payload
-contents reduce bandwidth.
+`disclosure=topology`. If the resolver advertises topology support
+in `/meta.disclosures` it MUST honor the parameter and return the
+topology shape, letting clients that don't need payload contents
+reduce bandwidth. If the resolver does NOT advertise topology
+support, it MAY EITHER ignore the parameter and return the full
+history form OR reject with `OPERATION_NOT_SUPPORTED` (405) —
+implementer's choice, but the behavior MUST be consistent across
+calls so clients can distinguish "feature unavailable" from
+"feature off for this object".
 
 A `read_topology` token presented to GET history WITHOUT
 `disclosure=topology` is scope-insufficient and MUST be rejected with
-`INVALID_CAPABILITY` (403) per §11.5.2 step 5(b). Absent the
-`disclosure` parameter (and absent a `read_topology` token), the
-resolver returns the full history form (§12.2.1) when the caller's
-scope permits.
+`INVALID_CAPABILITY` (403) per the §11.5.2 step 5 scope table.
+Absent the `disclosure` parameter (and absent a `read_topology`
+token), the resolver returns the full history form (§12.2.1) when
+the caller's scope permits.
 
 ##### 11.5.6.3 Topology Response Shape
 
@@ -2382,6 +2394,17 @@ Verification:
    top-level fields in the response.
 3. JCS-canonicalize that object.
 4. Verify the Ed25519 signature against the resulting bytes.
+
+If any step fails — `key_id` does not resolve, the public key
+returned is outside its `not_before`/`not_after` window (§11.2), or
+the Ed25519 signature does not verify — the response MUST be
+treated as untrusted. Consumers MUST NOT cache it, persist it, act
+on it, or surface it to downstream verifiers as if it had been
+attested. Consumers SHOULD retry once against the same authority
+(the failure may be a transient resolver misconfiguration) and
+SHOULD escalate to operators if the failure persists, since a
+signature mismatch is the wire-level signal of resolver compromise
+or man-in-the-middle.
 
 The topology signature attests that the resolver, acting for the
 authority, observed a chain with exactly this shape at the time of

--- a/spec/phip-core.md
+++ b/spec/phip-core.md
@@ -2404,10 +2404,8 @@ verification at any conformant peer.
 Verification:
 
 1. Resolve `key_id` to the public key (§11.2).
-2. Construct a JSON object containing EXACTLY
-   `disclosure`, `page_length`, `phip_id`, and `topology`, with
-   their verbatim values from the response. Ignore all other
-   top-level fields in the response.
+2. Construct the canonical signed object from the four fields named
+   above (`disclosure`, `page_length`, `phip_id`, `topology`).
 3. JCS-canonicalize that object.
 4. Verify the Ed25519 signature against the resulting bytes.
 
@@ -2450,7 +2448,7 @@ response served from an HTTP cache cannot be trusted because the
 freshness guarantee that `topology_signature` provides is bound to
 the time of signing.
 
-##### 11.5.6.5 Pagination
+##### 11.5.6.5 Pagination and Order
 
 Topology mode honors the same `limit` and `cursor` parameters as
 full history (§12.2.1). The `topology_signature` covers only the
@@ -2458,6 +2456,16 @@ events on the current page; consumers stitching paginated topology
 MUST verify each page's signature independently AND check the
 inter-page `previous_hash`/`event_hash` link (§11.5.6.4) to confirm
 the stitched chain is contiguous.
+
+Topology mode MUST return events in ascending chain order — oldest
+first, genesis at index 0 of the first page. The `?order` query
+parameter from §12.2.1 is ignored in topology mode; resolvers MUST
+NOT honor `?order=desc` for a `?disclosure=topology` request.
+Ascending order is mandatory so the §11.5.6.4 chain-walk check
+(`entry[N].previous_hash == entry[N-1].event_hash`) applies
+uniformly; a descending topology would invert the check, requiring
+consumers to special-case direction and defeating the purpose of
+having a single canonical verification path.
 
 ##### 11.5.6.6 Cross-Authority Composition
 

--- a/spec/phip-core.md
+++ b/spec/phip-core.md
@@ -2147,7 +2147,7 @@ The `phip:access` attribute namespace defines the following fields:
 |---|---|
 | `public` | Anyone may GET, read history, and match in QUERY. Default if `phip:access` is absent. |
 | `authenticated` | Caller MUST present a valid capability token with any `read_*` scope appropriate to the requested operation (§11.5.2 step 5), regardless of `granted_to` |
-| `capability` | Caller MUST present a capability token whose `granted_to` matches the requesting actor and whose scope covers the requested operation |
+| `capability` | Caller MUST present a capability token whose `granted_to` matches the requesting actor (or is the literal `"*"`, which makes the token presenter-anonymous; see §11.3.1) and whose scope covers the requested operation |
 | `private` | No external reads. Only the authority itself may read. |
 
 The policy applies to GET (`/resolve/`), GET history (`/history/`), and 
@@ -2180,7 +2180,7 @@ order:
    |---|---|
    | GET (state) | `read_state` or `read_history` |
    | GET history (default response) | `read_history` |
-   | GET history with `?disclosure=topology` | `read_history` or `read_topology` (the latter requires the resolver to advertise topology in `/meta.disclosures`; otherwise return `OPERATION_NOT_SUPPORTED` (405) — see §11.5.6.1) |
+   | GET history with `?disclosure=topology` | `read_history` or `read_topology` |
    | QUERY | `read_query` |
 
    A presented scope that does not appear in the matching row is
@@ -2188,6 +2188,15 @@ order:
    (403). In particular, a `read_topology` token presented to any
    operation other than GET history with `?disclosure=topology` is
    scope-insufficient.
+
+   Separately from scope coverage: if the operation requires an
+   optional feature the resolver does not advertise (currently:
+   topology disclosure via `/meta.disclosures`, §11.5.6.1), the
+   resolver MUST return `OPERATION_NOT_SUPPORTED` (405) regardless
+   of whether the presented scope would otherwise cover the
+   operation. This check applies even when scope coverage is
+   nominally satisfied — feature availability is a precondition,
+   not a scope question.
 
 6. Verify the token's `object_filter` matches the target `phip_id`. For 
    QUERY, the filter restricts which objects can be returned in the 
@@ -2225,6 +2234,12 @@ to a restricted object MUST NOT include `current_head` if the pushing
 actor lacks a `read_state` or `read_history` scope; the resolver MUST 
 instead return `ACCESS_DENIED` (403) and require the pusher to obtain 
 read scope before retrying.
+
+The above restrictions do not apply to topology disclosure (§11.5.6).
+Topology mode is the canonical disclosed view of chain head and
+shape — the last entry's `event_hash` IS the chain head, exposed
+deliberately under its own scope and authorization rules. It is not
+a "side channel" in the sense of this section.
 
 #### 11.5.5 Public-By-Default Rationale
 
@@ -2288,9 +2303,10 @@ topology shape, letting clients that don't need payload contents
 reduce bandwidth. If the resolver does NOT advertise topology
 support, it MAY EITHER ignore the parameter and return the full
 history form OR reject with `OPERATION_NOT_SUPPORTED` (405) —
-implementer's choice, but the behavior MUST be consistent across
-calls so clients can distinguish "feature unavailable" from
-"feature off for this object".
+implementer's choice. Resolvers SHOULD pick one of these two
+behaviors and apply it consistently; flipping between calls makes
+it hard for clients to distinguish "feature unavailable" from
+"feature off for this object."
 
 A `read_topology` token presented to GET history WITHOUT
 `disclosure=topology` is scope-insufficient and MUST be rejected with
@@ -2339,7 +2355,7 @@ Each topology entry MUST contain exactly these five fields:
 | `type` | Verbatim event type. An authority MAY substitute the literal string `"redacted"` if the type itself is sensitive |
 | `timestamp` | Verbatim from the underlying full event |
 | `previous_hash` | Verbatim from the underlying full event |
-| `event_hash` | `sha256:` + 64-hex of the JCS canonicalization of the full underlying event (Section 10.3) — the same value that would appear as `previous_hash` on the next event |
+| `event_hash` | `sha256:` + 64-hex of the JCS canonicalization of the full underlying event (Section 10.3) — the same value that would appear as `previous_hash` on the next event. The `event_hash` of the chronologically last entry on the final page IS the chain head referenced in §11.5.4; topology mode deliberately exposes it under this disclosure's authorization rules |
 
 The `payload`, `actor`, and per-event `signature` fields MUST NOT
 appear in topology mode.

--- a/spec/phip-core.md
+++ b/spec/phip-core.md
@@ -2510,6 +2510,18 @@ Topology mode is selective disclosure, not anonymization:
   SHOULD substitute `"redacted"` for `type` when the type taxonomy
   itself is information they wish to withhold.
 
+##### 11.5.6.8 Reference Material
+
+- Canonical wire bytes and verification expectations:
+  `tests/vectors/topology/cases.json` — five fixtures covering
+  signature verification, chain walk, envelope tampering, chain-link
+  tampering, and inter-page stitching.
+- HTTP-level conformance assertions: `tests/conformance/run.js` §21,
+  covering response shape on a public object plus token-gated
+  paths on a restricted object (read_topology + `?disclosure=topology`,
+  missing disclosure parameter, missing token, scope-insufficient
+  GET state).
+
 ### 11.6 Caller Authentication
 
 Capability tokens (Section 11.3) declare *what* an actor is permitted 

--- a/spec/phip-core.md
+++ b/spec/phip-core.md
@@ -1895,7 +1895,7 @@ The token shape is defined by `schemas/capability-token.json`
 | `phip_capability` | string | MUST | Version. MUST be `"1.0"` |
 | `token_id` | string (UUID) | MUST | Unique identifier for this token |
 | `granted_by` | PhIP URI | MUST | The authority issuing the token. MUST be an `actor` in the target namespace |
-| `granted_to` | PhIP URI or `"*"` | MUST | The actor authorized to use this token. The literal string `"*"` grants the token to any presenter and disables the §11.5.2 step-7 actor match. Issuers SHOULD restrict `"*"` tokens to non-write, low-leakage scopes (notably `read_topology`); a `"*"` token with `read_history`, `read_query`, or any push scope is effectively a publication and SHOULD be rejected at policy-review time |
+| `granted_to` | PhIP URI or `"*"` | MUST | The actor authorized to use this token. The literal string `"*"` grants the token to any presenter and disables the §11.5.2 step-7 actor match. Issuers SHOULD restrict `"*"` tokens to non-write, low-leakage scopes (notably `read_topology`); a `"*"` token with `read_history`, `read_query`, or any push scope is effectively a publication and SHOULD be rejected at policy-review time. Combining `granted_to: "*"` with `object_filter: "*"` (or any wildcard that matches the whole authority) yields a universal grant and SHOULD NOT be issued except when the authority explicitly intends an authority-wide public attestation; auditors checking issuance logs should flag this pattern. When `granted_to: "*"`, the token's `granted_by` SHOULD reference a key resource dedicated to public-attestation issuance (e.g., `phip://{authority}/keys/public-topology-2026`) rather than the authority root key, so the key can be rotated independently without disturbing other token classes. |
 | `scope` | string | MUST | Permission granted. See 11.3.2 |
 | `object_filter` | string | MUST | Glob pattern matching target `phip_id`s. Uses `*` for wildcard |
 | `not_before` | string (ISO 8601) | MUST | Token validity start |
@@ -1915,8 +1915,8 @@ any object whose `phip_id` starts with that prefix.
 | `push_measurements` | Append `measurement` events only |
 | `push_relations` | Append `relation_added` and `relation_removed` events only |
 | `read_state` | Read object projection via GET (no history) |
-| `read_history` | Read object projection AND full event history |
-| `read_topology` | Read chain topology (event IDs, types, timestamps, `previous_hash` links) of an object's history, without payloads, actors, or per-event signatures. See §11.5.6 |
+| `read_history` | Read object projection AND full event history. A `read_history` token MAY also request topology mode via `?disclosure=topology` (§11.5.6) — topology is a proper subset of what `read_history` already grants |
+| `read_topology` | Read chain topology (event IDs, types, timestamps, `previous_hash` links, `event_hash` per entry) of an object's history, without payloads, actors, or per-event signatures. ONLY satisfies GET history when `?disclosure=topology` is present; see §11.5.6 |
 | `read_query` | Match objects via QUERY |
 
 A token with `push_events` scope is a broad grant. The narrower scopes 
@@ -2174,13 +2174,18 @@ order:
 4. Verify the token signature, expiry, and `granted_to` per Section 
    11.3.4 steps 1–4.
 5. Verify the token's `scope` covers the requested operation:
+   - If `scope == "read_topology"`: (a) if the resolver does not
+     advertise topology disclosure in `/meta.disclosures` (§12.7),
+     reject with `OPERATION_NOT_SUPPORTED` (405) — the token is
+     structurally valid but the resolver cannot honor it; (b)
+     otherwise, the token covers GET history only when the request
+     URL contains `disclosure=topology`. A `read_topology` token
+     presented WITHOUT that query parameter is treated as
+     scope-insufficient and rejected with `INVALID_CAPABILITY`
+     (403).
    - GET requires `read_state` or `read_history`
-   - GET history requires `read_history`, OR `read_topology` when both
-     (i) the resolver supports topology disclosure (§11.5.6) and
-     (ii) the request URL includes `disclosure=topology`. A
-     `read_topology` token presented WITHOUT `disclosure=topology` MUST
-     be treated as scope-mismatched and rejected with `ACCESS_DENIED`
-     (403); it does not satisfy GET history on its own.
+   - GET history requires `read_history` for the default response,
+     OR `read_topology` per the substep above
    - QUERY requires `read_query`
 6. Verify the token's `object_filter` matches the target `phip_id`. For 
    QUERY, the filter restricts which objects can be returned in the 
@@ -2246,9 +2251,10 @@ The full response schema is defined by `schemas/topology-response.json`
 Topology disclosure is OPTIONAL. A resolver advertises support by
 including `"topology"` in the `disclosures` array of its `/meta`
 document (§12.7). Resolvers that do not advertise topology support
-MUST reject `read_topology` tokens with `INVALID_CAPABILITY` (403);
-clients SHOULD check `/meta` before presenting a `read_topology`
-token rather than probing.
+MUST reject `read_topology` tokens with `OPERATION_NOT_SUPPORTED`
+(405) per §11.5.2 step 5(a) — the token is structurally valid but
+the resolver cannot honor it. Clients SHOULD check `/meta` before
+presenting a `read_topology` token rather than probing.
 
 The `read_topology` scope grants **only** the topology disclosure
 mode described in this subsection. It does NOT authorize GET state,
@@ -2275,10 +2281,11 @@ return the topology shape. This lets clients that don't need payload
 contents reduce bandwidth.
 
 A `read_topology` token presented to GET history WITHOUT
-`disclosure=topology` MUST be rejected with `ACCESS_DENIED` (403) per
-§11.5.2 step 5. Absent the `disclosure` parameter, the resolver
-returns the full history form (§12.2.1) when the caller's scope
-permits.
+`disclosure=topology` is scope-insufficient and MUST be rejected with
+`INVALID_CAPABILITY` (403) per §11.5.2 step 5(b). Absent the
+`disclosure` parameter (and absent a `read_topology` token), the
+resolver returns the full history form (§12.2.1) when the caller's
+scope permits.
 
 ##### 11.5.6.3 Topology Response Shape
 
@@ -2333,24 +2340,48 @@ count their own running total.
 
 ##### 11.5.6.4 Topology Signature and Chain Verification
 
-The `topology_signature` covers the JCS canonicalization of the
-**response envelope object** `{ phip_id, page_length, disclosure,
-topology }` (the entire response document minus
-`topology_signature` and `next_cursor`). Signing the envelope — not
-just the `topology` array — binds the array to the object it
-describes and to the disclosure mode it was returned under;
-otherwise a compromised resolver could re-attribute a valid
-signature to a different `phip_id`. The `key_id` MUST be a key
-resource (§11.2) of the authority serving the resolver.
+The `topology_signature` covers the JCS canonicalization of a
+**canonical signed object** containing exactly four fields drawn
+verbatim from the response envelope:
+
+| Key | Source |
+|---|---|
+| `disclosure` | The string `"topology"` |
+| `page_length` | The envelope's `page_length` integer |
+| `phip_id` | The envelope's `phip_id` string |
+| `topology` | The envelope's `topology` array verbatim |
+
+(Listed above in their JCS-sorted order — UTF-16 code-unit ascending.
+JCS will produce the same byte sequence regardless of how the
+implementer enumerates the keys when building the object, but the
+canonical form is shown here so implementers can produce test
+vectors.)
+
+Signing the envelope — not just the `topology` array — binds the
+array to the object it describes and to the disclosure mode it was
+returned under; otherwise a compromised resolver could re-attribute
+a valid signature to a different `phip_id`. The `key_id` MUST be a
+key resource (§11.2) of the authority serving the resolver,
+typically reached via the resolver-as-actor bootstrap pattern
+(§11.2.4).
+
+A response document MAY carry top-level fields beyond the canonical
+four (the topology-response schema declares
+`additionalProperties: true`). Verifiers MUST construct the signed
+object from EXACTLY the four canonical fields and MUST ignore any
+extras (e.g., resolver-emitted `served_at`, request IDs, debug
+hints). Including additional fields in the signed bytes would break
+verification at any conformant peer.
 
 Verification:
 
 1. Resolve `key_id` to the public key (§11.2).
-2. Construct the JCS canonicalization of
-   `{ phip_id, page_length, disclosure, topology }` from the
-   response, in that order — every implementation produces identical
-   bytes (the order is enforced by JCS's lexical key sort).
-3. Verify the Ed25519 signature against those bytes.
+2. Construct a JSON object containing EXACTLY
+   `disclosure`, `page_length`, `phip_id`, and `topology`, with
+   their verbatim values from the response. Ignore all other
+   top-level fields in the response.
+3. JCS-canonicalize that object.
+4. Verify the Ed25519 signature against the resulting bytes.
 
 The topology signature attests that the resolver, acting for the
 authority, observed a chain with exactly this shape at the time of
@@ -2373,7 +2404,12 @@ response and the resolver's public key:
 A resolver MUST sign the topology fresh for each response; topology
 signatures MUST NOT be cached across calls, because pagination
 cursors and `not_before`/`expires` windows may change the visible
-slice.
+slice. Resolvers MUST set `Cache-Control: no-store` (or equivalently
+`private, max-age=0`) on topology responses, overriding the longer
+caching guidance for projection responses in §4.3.2. A topology
+response served from an HTTP cache cannot be trusted because the
+freshness guarantee that `topology_signature` provides is bound to
+the time of signing.
 
 ##### 11.5.6.5 Pagination
 

--- a/spec/phip-core.md
+++ b/spec/phip-core.md
@@ -1895,7 +1895,7 @@ The token shape is defined by `schemas/capability-token.json`
 | `phip_capability` | string | MUST | Version. MUST be `"1.0"` |
 | `token_id` | string (UUID) | MUST | Unique identifier for this token |
 | `granted_by` | PhIP URI | MUST | The authority issuing the token. MUST be an `actor` in the target namespace |
-| `granted_to` | PhIP URI | MUST | The actor authorized to use this token |
+| `granted_to` | PhIP URI or `"*"` | MUST | The actor authorized to use this token. The literal string `"*"` grants the token to any presenter and disables the §11.5.2 step-7 actor match. Issuers SHOULD restrict `"*"` tokens to non-write, low-leakage scopes (notably `read_topology`); a `"*"` token with `read_history`, `read_query`, or any push scope is effectively a publication and SHOULD be rejected at policy-review time |
 | `scope` | string | MUST | Permission granted. See 11.3.2 |
 | `object_filter` | string | MUST | Glob pattern matching target `phip_id`s. Uses `*` for wildcard |
 | `not_before` | string (ISO 8601) | MUST | Token validity start |
@@ -2175,16 +2175,20 @@ order:
    11.3.4 steps 1–4.
 5. Verify the token's `scope` covers the requested operation:
    - GET requires `read_state` or `read_history`
-   - GET history requires `read_history`, OR `read_topology` if the
-     resolver supports topology disclosure (§11.5.6) and the caller has
-     explicitly requested topology mode
+   - GET history requires `read_history`, OR `read_topology` when both
+     (i) the resolver supports topology disclosure (§11.5.6) and
+     (ii) the request URL includes `disclosure=topology`. A
+     `read_topology` token presented WITHOUT `disclosure=topology` MUST
+     be treated as scope-mismatched and rejected with `ACCESS_DENIED`
+     (403); it does not satisfy GET history on its own.
    - QUERY requires `read_query`
 6. Verify the token's `object_filter` matches the target `phip_id`. For 
    QUERY, the filter restricts which objects can be returned in the 
    match list — objects outside the filter MUST be silently omitted, 
    not returned with an error.
 7. If the policy is `capability`, verify the requesting actor matches 
-   `granted_to`.
+   `granted_to`. When `granted_to` is the literal string `"*"`, this 
+   check is skipped (§11.3.1) — the token grants any presenter.
 
 If any check fails, return `ACCESS_DENIED` (403) for policy mismatches 
 or `INVALID_CAPABILITY` (403) for token defects.
@@ -2234,20 +2238,30 @@ under active stewardship without seeing its payloads.
 The `read_topology` scope (§11.3.2) and this subsection define an
 optional disclosure mode that fills this gap.
 
+The full response schema is defined by `schemas/topology-response.json`
+(machine-readable JSON Schema) alongside the prose below.
+
 ##### 11.5.6.1 Scope and Limits
 
 Topology disclosure is OPTIONAL. A resolver advertises support by
-including `read_topology` in the scopes it issues tokens for; absence
-implies no support. A resolver that does not implement topology mode
-MUST reject `read_topology` tokens with `INVALID_CAPABILITY` (403).
+including `"topology"` in the `disclosures` array of its `/meta`
+document (§12.7). Resolvers that do not advertise topology support
+MUST reject `read_topology` tokens with `INVALID_CAPABILITY` (403);
+clients SHOULD check `/meta` before presenting a `read_topology`
+token rather than probing.
 
-Topology mode is read-only and applies only to GET history requests
-(§12.2.1). It does not apply to GET state, QUERY, or any PUSH operation.
+The `read_topology` scope grants **only** the topology disclosure
+mode described in this subsection. It does NOT authorize GET state,
+the default GET history response, QUERY, or any PUSH operation. A
+caller who needs both topology and current state MUST hold a
+`read_state` (or stronger) token in addition.
 
 ##### 11.5.6.2 Requesting Topology
 
-A caller holding a `read_topology` token requests topology mode by
-appending `?disclosure=topology` to the GET history URL:
+A caller requests topology mode by appending `disclosure=topology` to
+the GET history URL. The `disclosure` query parameter is the only
+trigger; resolvers MUST NOT switch to topology mode based on
+Accept-headers, scope inference, or any other heuristic.
 
 ```
 GET https://{authority}/.well-known/phip/history/{namespace}/{local-id}
@@ -2255,32 +2269,38 @@ GET https://{authority}/.well-known/phip/history/{namespace}/{local-id}
 Authorization: PhIP-Capability <token>
 ```
 
-A caller holding `read_history` MAY also request `disclosure=topology`,
-in which case the resolver MUST honor it and return the topology shape.
-This lets clients that don't need payload contents reduce bandwidth.
+A caller holding `read_history` MAY also include
+`disclosure=topology`, in which case the resolver MUST honor it and
+return the topology shape. This lets clients that don't need payload
+contents reduce bandwidth.
 
-Absent the `disclosure` parameter, the resolver returns the full history
-form (§12.2.1) when the caller's scope permits.
+A `read_topology` token presented to GET history WITHOUT
+`disclosure=topology` MUST be rejected with `ACCESS_DENIED` (403) per
+§11.5.2 step 5. Absent the `disclosure` parameter, the resolver
+returns the full history form (§12.2.1) when the caller's scope
+permits.
 
 ##### 11.5.6.3 Topology Response Shape
 
 ```json
 {
   "phip_id": "phip://acme.example/projects/widget-v3",
-  "history_length": 12,
+  "page_length": 2,
   "disclosure": "topology",
   "topology": [
     {
-      "event_id": "evt-...",
+      "event_id": "evt-9a0c...-...",
       "type": "created",
       "timestamp": "2026-01-15T09:00:00Z",
-      "previous_hash": "genesis"
+      "previous_hash": "genesis",
+      "event_hash": "sha256:1a4b..."
     },
     {
-      "event_id": "evt-...",
+      "event_id": "evt-7e2d...-...",
       "type": "attribute_update",
       "timestamp": "2026-01-22T14:30:00Z",
-      "previous_hash": "sha256:..."
+      "previous_hash": "sha256:1a4b...",
+      "event_hash": "sha256:c91f..."
     }
   ],
   "topology_signature": {
@@ -2292,7 +2312,7 @@ form (§12.2.1) when the caller's scope permits.
 }
 ```
 
-Each topology entry MUST contain exactly these four fields:
+Each topology entry MUST contain exactly these five fields:
 
 | Field | Source |
 |---|---|
@@ -2300,35 +2320,69 @@ Each topology entry MUST contain exactly these four fields:
 | `type` | Verbatim event type. An authority MAY substitute the literal string `"redacted"` if the type itself is sensitive |
 | `timestamp` | Verbatim from the underlying full event |
 | `previous_hash` | Verbatim from the underlying full event |
+| `event_hash` | `sha256:` + 64-hex of the JCS canonicalization of the full underlying event (Section 10.3) — the same value that would appear as `previous_hash` on the next event |
 
-The `payload`, `actor`, and per-event `signature` fields MUST NOT appear
-in topology mode.
+The `payload`, `actor`, and per-event `signature` fields MUST NOT
+appear in topology mode.
 
-##### 11.5.6.4 Topology Signature
+The response envelope reports `page_length` — the number of entries
+in this `topology` page — and NOT total chain length. Exposing total
+chain length would give every topology reader a stable fingerprint
+of the object (§11.5.6.7). Consumers walking paginated topology MUST
+count their own running total.
+
+##### 11.5.6.4 Topology Signature and Chain Verification
 
 The `topology_signature` covers the JCS canonicalization of the
-`topology` array. The `key_id` MUST be a key resource (§11.2) of the
-authority serving the resolver. Verification:
+**response envelope object** `{ phip_id, page_length, disclosure,
+topology }` (the entire response document minus
+`topology_signature` and `next_cursor`). Signing the envelope — not
+just the `topology` array — binds the array to the object it
+describes and to the disclosure mode it was returned under;
+otherwise a compromised resolver could re-attribute a valid
+signature to a different `phip_id`. The `key_id` MUST be a key
+resource (§11.2) of the authority serving the resolver.
+
+Verification:
 
 1. Resolve `key_id` to the public key (§11.2).
-2. JCS-encode the `topology` array verbatim.
+2. Construct the JCS canonicalization of
+   `{ phip_id, page_length, disclosure, topology }` from the
+   response, in that order — every implementation produces identical
+   bytes (the order is enforced by JCS's lexical key sort).
 3. Verify the Ed25519 signature against those bytes.
 
 The topology signature attests that the resolver, acting for the
-authority, observed a chain with exactly this shape at the time of the
-response. It does NOT attest to chain integrity end-to-end — that
-requires `read_history` and per-event signature verification.
+authority, observed a chain with exactly this shape at the time of
+the response. It does NOT attest end-to-end chain integrity — for
+that, a verifier needs the full event payloads and per-event
+signatures via `read_history`.
+
+What topology consumers **can** verify on their own, using only the
+response and the resolver's public key:
+
+- The response envelope is signed by the authority (anti-spoofing).
+- Within a single page, the chain shape is consistent: for each
+  entry N > 0, `entry[N].previous_hash` MUST equal
+  `entry[N-1].event_hash`. A mismatch indicates a fabricated or
+  corrupted page.
+- Across pages, `page[K+1].topology[0].previous_hash` MUST equal
+  `page[K].topology[-1].event_hash` when the pages were obtained in
+  natural chain order.
 
 A resolver MUST sign the topology fresh for each response; topology
-signatures MUST NOT be cached across calls, because pagination cursors
-and `not_before`/`expires` windows may change the visible slice.
+signatures MUST NOT be cached across calls, because pagination
+cursors and `not_before`/`expires` windows may change the visible
+slice.
 
 ##### 11.5.6.5 Pagination
 
-Topology mode honors the same `limit` and `cursor` parameters as full
-history (§12.2.1). The `topology_signature` covers only the events in
-the current page; consumers stitching paginated topology MUST verify
-each page's signature independently.
+Topology mode honors the same `limit` and `cursor` parameters as
+full history (§12.2.1). The `topology_signature` covers only the
+events on the current page; consumers stitching paginated topology
+MUST verify each page's signature independently AND check the
+inter-page `previous_hash`/`event_hash` link (§11.5.6.4) to confirm
+the stitched chain is contiguous.
 
 ##### 11.5.6.6 Cross-Authority Composition
 
@@ -2338,28 +2392,40 @@ composition:
 
 - A `design` object at `phip://acme.example/projects/widget-v3` has
   `phip:access.policy = capability`.
-- The authority pre-issues a long-lived `read_topology` token granted
-  to the wildcard actor `phip://*/actor/*` (no `granted_to` restriction
-  beyond presence of the token) and publishes the token alongside the
-  authority record.
-- An `assembly` object instance of that design is public; downstream
-  readers resolving the assembly can follow the `instance_of` relation
-  to the design URI, present the public topology token, and confirm
-  the design's lifecycle shape without seeing payloads.
+- The authority issues a long-lived capability token with
+  `scope: "read_topology"`, `granted_to: "*"` (§11.3.1), and
+  `object_filter: "phip://acme.example/projects/widget-v3"` — and
+  publishes the token alongside the authority record.
+- An `assembly` object that `instance_of`s that design is `public`;
+  downstream readers resolving the assembly can follow the
+  `instance_of` relation to the design URI, present the public
+  `"*"` topology token, and confirm the design's lifecycle shape
+  without seeing payloads.
 
-Authorities that do not wish to publicly attest topology can simply not
-issue `read_topology` tokens for the restricted object; the existing
-`ACCESS_DENIED` (403) behavior is unchanged.
+Authorities that do not wish to publicly attest topology can simply
+not issue `read_topology` tokens for the restricted object; the
+existing `ACCESS_DENIED` (403) behavior is unchanged.
 
 ##### 11.5.6.7 What Topology Does Not Protect
 
 Topology mode is selective disclosure, not anonymization:
 
-- Event count, event types, and timestamps are revealed. Inference
-  from those alone may be material — e.g., a burst of measurement
-  events at hour H may correlate with a known production incident.
+- Event types and timestamps are revealed. Inference from those
+  alone may be material — e.g., a burst of measurement events at
+  hour H may correlate with a known production incident; the
+  cadence of `state_transition` events leaks process duration.
+- `page_length` is per-page, but a determined reader can paginate
+  to the end and count. Authorities that consider the total event
+  count itself sensitive (e.g., a count of corrective
+  `attribute_update`s) SHOULD NOT issue `read_topology` tokens.
+- `event_id` and `event_hash` are stable per-event identifiers; a
+  reader who later gains `read_history` can link them to specific
+  payloads. Treat anything a topology reader sees as permanently
+  disclosed.
 - Authorities that consider timing or event-type cadence sensitive
-  SHOULD NOT issue `read_topology` tokens for those objects.
+  SHOULD NOT issue `read_topology` tokens for those objects, and
+  SHOULD substitute `"redacted"` for `type` when the type taxonomy
+  itself is information they wish to withhold.
 
 ### 11.6 Caller Authentication
 
@@ -3065,6 +3131,7 @@ fields:
 | `namespaces` | array of strings | MUST | Namespaces this resolver will accept CREATEs into |
 | `schema_namespaces` | array of strings | SHOULD | Attribute namespaces whose schemas this resolver validates (e.g. `phip:mechanical`, `phip:software`) |
 | `supported_operations` | array of strings | SHOULD | Subset of `["create", "get", "push", "query", "history", "batch_create", "batch_push"]` |
+| `disclosures` | array of strings | MAY | Optional disclosure modes this resolver honors on GET history beyond the default full response. Currently only `"topology"` is defined (§11.5.6). Absence implies no disclosure modes are supported; clients SHOULD NOT probe |
 | `query_capabilities` | object | MAY | Optional map describing supported filter operators, glob syntax, sort orders |
 | `root_key` | string | SHOULD | PhIP URI of this authority's root key (Section 4.6.1). Clients use this to anchor trust for transfer verification |
 | `mirror_urls` | array of strings | MAY | URLs of read-only mirrors hosting frozen snapshots of this authority's records. See Section 4.6.5 |
@@ -3548,7 +3615,7 @@ Issues identified through scenario stress-testing and systematic review.
 
 | # | Issue | Severity | Notes |
 |---|---|---|---|
-| A42 | Selective history disclosure | Medium | `read_state` and `read_history` are the only read scopes on history. There is no middle ground for "this object exists, has chain shape X, was last touched at T" without exposing payloads. Surfaces in the "private design with publicly listed instances" pattern: a public `assembly` `instance_of` a private `design`; downstream readers want to confirm the design's chain shape without seeing its contents. Proposed: optional topology disclosure mode (§11.5.6) with new `read_topology` scope. |
+| A42 | Selective history disclosure | Medium | `read_state` and `read_history` were the only read scopes on history. There was no middle ground for "this object exists, has chain shape X, was last touched at T" without exposing payloads. Surfaces in the "private design with publicly listed instances" pattern: a public `assembly` `instance_of` a private `design`; downstream readers want to confirm the design's chain shape without seeing its contents. Proposed resolution: optional topology disclosure mode (§11.5.6) with `read_topology` scope; presenter-anonymous `granted_to: "*"` tokens (§11.3.1); `/meta.disclosures` advertisement (§12.7); envelope-signed response with per-entry `event_hash` for chain-walk verification. |
 
 ---
 

--- a/tests/conformance/README.md
+++ b/tests/conformance/README.md
@@ -44,18 +44,29 @@ without CREATE collisions.
 
 ## What it tests
 
-| # | Section  | Behaviour                                                   |
-|---|----------|-------------------------------------------------------------|
-| 1 | 11.2.4   | Self-signed bootstrap actor CREATE                          |
-| 2 | 12.1     | CREATE component in concept state                           |
-| 3 | 12.2     | GET projects `phip_id`, `state`, `history_length`, head     |
-| 4 | 12.3, 9  | PUSH `state_transition` concept → design                    |
-| 5 | 12.3     | PUSH `attribute_update` into `phip:software`                |
-| 6 | 9.2.1    | Invalid transition rejected with `INVALID_TRANSITION`       |
-| 7 | 12.3.1   | Stale `previous_hash` → 409 `CHAIN_CONFLICT` with head      |
-| 8 | 12.2.1   | `/history/` returns all events with verifiable chain        |
-| 9 | 12.4     | QUERY by `object_type` and by `state`                       |
-| 10| 12.5     | `OBJECT_NOT_FOUND`, `OBJECT_EXISTS` envelopes               |
+| #  | Section          | Behaviour                                                   |
+|----|------------------|-------------------------------------------------------------|
+| 1  | 11.2.4           | Self-signed bootstrap actor CREATE                          |
+| 2  | 12.1             | CREATE component in concept state                           |
+| 3  | 12.2             | GET projects `phip_id`, `state`, `history_length`, head     |
+| 4  | 12.3, 9          | PUSH `state_transition` concept → design                    |
+| 5  | 12.3             | PUSH `attribute_update` into `phip:software`                |
+| 6  | 9.2.1            | Invalid transition rejected with `INVALID_TRANSITION`       |
+| 7  | 12.3.1           | Stale `previous_hash` → 409 `CHAIN_CONFLICT` with head      |
+| 8  | 12.2.1           | `/history/` returns all events with verifiable chain        |
+| 9  | 12.4             | QUERY by `object_type` and by `state`                       |
+| 10 | 12.5             | `OBJECT_NOT_FOUND`, `OBJECT_EXISTS` envelopes               |
+| 11 | 12.7             | `/meta` document shape; `disclosures` is array-of-strings when present. OPTIONAL — skipped when `/meta` is absent |
+| 12 | 12.5             | Batch CREATE — mixed-outcome 207 and all-succeed 200. OPTIONAL — skipped when `batch_create` not advertised |
+| 13 | 6.2, 6.3         | `design` object type and `instance_of` target constraint    |
+| 14 | 7.4              | `DANGLING_RELATION` for same-authority broken refs          |
+| 15 | 10.4.1           | `process` event yield_fraction sum ≤ 1 + ε                  |
+| 16 | 10.5.1           | `lot_split`/`lot_merge` mass conservation                   |
+| 17 | 11.4.2           | `measurement` event payload shape                           |
+| 18 | 11.5             | `phip:access` policies (`private`, `authenticated`); valid/forged/expired capability tokens |
+| 19 | 4.6              | `authority_transfer` event acceptance                       |
+| 20 | 4.5, 4.6         | Federation mechanics — delegation 307, successor 308. OPTIONAL — opt-in via `/meta.delegations` / `/meta.successor` |
+| 21 | 11.5.6           | Topology disclosure — public-object shape + signature + chain walk; restricted-object token paths (`read_topology "*"`, missing disclosure 403, missing token 403, GET-state scope mismatch 403). OPTIONAL — skipped when `/meta.disclosures` lacks `"topology"` |
 
 The suite signs all events with the first fixed Ed25519 keypair from
 `vectors/ed25519/keypair.json` — the server therefore only needs to verify
@@ -64,7 +75,6 @@ signatures, not hold any credentials of its own.
 ## Out of scope for v0.1
 
 * Cross-authority GET (resolver discovery — Section 4.3, currently `[TODO]`)
-* Capability tokens (Section 11.3) — v0 is intra-namespace only
 * Pagination cursor behaviour past 100 events
 * Archived-state `note`-only acceptance — added once operational-track
   CREATE is exercised

--- a/tests/conformance/run.js
+++ b/tests/conformance/run.js
@@ -1038,6 +1038,131 @@ async function main() {
     }
   }
 
+  // ── 21. Topology disclosure (§11.5.6 — OPTIONAL) ──────────────────
+  // Skips entire section if the resolver does not advertise
+  // /meta.disclosures: ["topology"]. When advertised, probes the
+  // /history endpoint with ?disclosure=topology against an object we
+  // created earlier in this run and verifies the response shape,
+  // ordering, signature mechanics, and chain-walk rule.
+  console.log(`\n[21] topology disclosure (§11.5.6, opt-in)`);
+  const supportsTopology = metaPublished
+    && Array.isArray(rMeta.body.disclosures)
+    && rMeta.body.disclosures.includes("topology");
+  if (!supportsTopology) {
+    console.log("  (skipped — /meta.disclosures does not include 'topology')");
+  } else {
+    const rTopo = await request(
+      "GET",
+      `/.well-known/phip/history/${NAMESPACE}/${OBJ_LOCAL_ID}?disclosure=topology`,
+    );
+    test("topology GET returns 200", rTopo.status === 200, `got ${rTopo.status}`);
+
+    const cacheCtl = rTopo.headers && (rTopo.headers["cache-control"] || "");
+    test(
+      "topology response sets Cache-Control: no-store (or max-age=0)",
+      typeof cacheCtl === "string"
+        && (cacheCtl.includes("no-store") || /max-age=\s*0\b/.test(cacheCtl)),
+      `got '${cacheCtl}'`,
+    );
+
+    const body = rTopo.body;
+    test("topology body has disclosure='topology'", body && body.disclosure === "topology");
+    test("topology body has phip_id matching the request", body && body.phip_id === OBJ_PHIP_ID);
+    test(
+      "topology body has page_length matching topology.length",
+      body && typeof body.page_length === "number"
+        && Array.isArray(body.topology) && body.page_length === body.topology.length,
+    );
+    test(
+      "topology entries have the five canonical fields and nothing else",
+      Array.isArray(body && body.topology)
+        && body.topology.every((e) => {
+          const ks = Object.keys(e).sort();
+          return ks.length === 5
+            && ks[0] === "event_hash"
+            && ks[1] === "event_id"
+            && ks[2] === "previous_hash"
+            && ks[3] === "timestamp"
+            && ks[4] === "type";
+        }),
+    );
+    test(
+      "topology first entry previous_hash === 'genesis' (ascending order)",
+      body && body.topology[0] && body.topology[0].previous_hash === "genesis",
+    );
+
+    // Chain walk: entry[N].previous_hash MUST equal entry[N-1].event_hash.
+    let walkOk = true;
+    for (let i = 1; body && body.topology && i < body.topology.length; i++) {
+      if (body.topology[i].previous_hash !== body.topology[i - 1].event_hash) {
+        walkOk = false;
+        break;
+      }
+    }
+    test("topology chain walk: previous_hash links match event_hashes", walkOk);
+
+    // Topology signature: covers JCS({disclosure, page_length, phip_id, topology}).
+    const sig = body && body.topology_signature;
+    test(
+      "topology_signature object present with algorithm/key_id/value",
+      sig && sig.algorithm === "Ed25519" && typeof sig.key_id === "string" && typeof sig.value === "string",
+    );
+
+    if (sig && sig.key_id) {
+      const canonicalSigned = {
+        disclosure: body.disclosure,
+        page_length: body.page_length,
+        phip_id: body.phip_id,
+        topology: body.topology,
+      };
+      const signedBytes = Buffer.from(canonicalize(canonicalSigned), "utf8");
+      const sigBytes = Buffer.from(sig.value, "base64url");
+
+      // Resolve the key_id to a public key (the resolver MUST expose it as
+      // an actor with phip:keys; §11.2.4). For the conformance probe we
+      // simply GET the actor and read its phip:keys.x.
+      const keyResolveUrl = sig.key_id.replace(/^phip:\/\/[^/]+/, "");
+      const rKey = await request("GET", `/.well-known/phip/resolve${keyResolveUrl}`);
+      const x = rKey.body
+        && rKey.body.attributes
+        && rKey.body.attributes["phip:keys"]
+        && rKey.body.attributes["phip:keys"].x;
+      if (!x) {
+        test(
+          "topology signing key resolves and exposes phip:keys.x",
+          false,
+          `could not resolve ${sig.key_id}`,
+        );
+      } else {
+        const rawPub = Buffer.from(x, "base64url");
+        const spki = Buffer.concat([Buffer.from("302a300506032b6570032100", "hex"), rawPub]);
+        const pubKey = crypto.createPublicKey({ key: spki, format: "der", type: "spki" });
+        const verified = crypto.verify(null, signedBytes, pubKey, sigBytes);
+        test("topology_signature verifies against resolved key", verified);
+      }
+    }
+
+    // ?order=desc MUST be ignored in topology mode (§11.5.6.5).
+    const rDesc = await request(
+      "GET",
+      `/.well-known/phip/history/${NAMESPACE}/${OBJ_LOCAL_ID}?disclosure=topology&order=desc`,
+    );
+    test(
+      "topology ignores ?order=desc (still ascending)",
+      rDesc.status === 200
+        && rDesc.body && rDesc.body.topology
+        && rDesc.body.topology[0] && rDesc.body.topology[0].previous_hash === "genesis",
+    );
+
+    // read_history token without ?disclosure=topology returns full history.
+    // (Bare GET history is already tested earlier; here we just confirm
+    // adding the param against a non-restricted object also yields topology.)
+
+    // Untokened request: still topology (object is public in our test run).
+    // But §11.5.6 grants this implicitly through normal /history access.
+    // No additional assertion — the first GET above covered it.
+  }
+
   // ── summary ───────────────────────────────────────────────────────
   console.log(`\n${pass} passed, ${fail} failed`);
   if (fail > 0) {

--- a/tests/conformance/run.js
+++ b/tests/conformance/run.js
@@ -436,6 +436,17 @@ async function main() {
       rMeta.headers && typeof rMeta.headers["cache-control"] === "string"
         && rMeta.headers["cache-control"].includes("max-age"),
     );
+    // If /meta.disclosures is present, it MUST be an array of strings per
+    // schemas/meta.json. A server that intends to advertise topology but
+    // mis-renders this field would otherwise silently fail the §21 skip
+    // gate without anyone noticing.
+    if ("disclosures" in rMeta.body) {
+      test(
+        "/meta.disclosures is an array of strings",
+        Array.isArray(rMeta.body.disclosures)
+          && rMeta.body.disclosures.every((d) => typeof d === "string"),
+      );
+    }
   }
 
   // ── 12. Batch CREATE — mixed outcomes → 207 ───────────────────────
@@ -1218,7 +1229,10 @@ async function main() {
       object_filter: TOPO_RESTRICTED_PHIP,
     });
 
-    // Path A: read_topology + ?disclosure=topology → 200 with topology body.
+    // Path A: read_topology + ?disclosure=topology → 200 with a
+    // well-formed, signed, chain-verifiable topology body. We re-run
+    // the same shape + signature + chain checks as the public-object
+    // probe above so the gated path is exercised at equal rigor.
     const rPathA = await request(
       "GET",
       `/.well-known/phip/history/${NAMESPACE}/${TOPO_RESTRICTED_LOCAL}?disclosure=topology`,
@@ -1230,10 +1244,80 @@ async function main() {
       rPathA.status === 200,
       `got ${rPathA.status}`,
     );
+
+    const bodyA = rPathA.body;
     test(
-      "topology+capability: response body is topology mode",
-      rPathA.body && rPathA.body.disclosure === "topology",
+      "topology+capability: response body is topology mode with matching phip_id",
+      bodyA && bodyA.disclosure === "topology" && bodyA.phip_id === TOPO_RESTRICTED_PHIP,
     );
+    test(
+      "topology+capability: page_length matches topology.length",
+      bodyA && typeof bodyA.page_length === "number"
+        && Array.isArray(bodyA.topology) && bodyA.page_length === bodyA.topology.length,
+    );
+    test(
+      "topology+capability: first entry previous_hash === 'genesis'",
+      bodyA && bodyA.topology[0] && bodyA.topology[0].previous_hash === "genesis",
+    );
+    test(
+      "topology+capability: entries have exactly the five canonical fields",
+      Array.isArray(bodyA && bodyA.topology)
+        && bodyA.topology.every((e) => {
+          const ks = Object.keys(e).sort();
+          return ks.length === 5
+            && ks[0] === "event_hash"
+            && ks[1] === "event_id"
+            && ks[2] === "previous_hash"
+            && ks[3] === "timestamp"
+            && ks[4] === "type";
+        }),
+    );
+
+    // Chain walk on the restricted object.
+    let walkOkA = true;
+    for (let i = 1; bodyA && bodyA.topology && i < bodyA.topology.length; i++) {
+      if (bodyA.topology[i].previous_hash !== bodyA.topology[i - 1].event_hash) {
+        walkOkA = false;
+        break;
+      }
+    }
+    test("topology+capability: chain walk holds", walkOkA);
+
+    // Signature verification on the restricted object.
+    const sigA = bodyA && bodyA.topology_signature;
+    test(
+      "topology+capability: topology_signature object well-formed",
+      sigA && sigA.algorithm === "Ed25519" && typeof sigA.key_id === "string" && typeof sigA.value === "string",
+    );
+    if (sigA && sigA.key_id) {
+      const canonicalSignedA = {
+        disclosure: bodyA.disclosure,
+        page_length: bodyA.page_length,
+        phip_id: bodyA.phip_id,
+        topology: bodyA.topology,
+      };
+      const signedBytesA = Buffer.from(canonicalize(canonicalSignedA), "utf8");
+      const sigBytesA = Buffer.from(sigA.value, "base64url");
+      const keyResolveUrlA = sigA.key_id.replace(/^phip:\/\/[^/]+/, "");
+      const rKeyA = await request("GET", `/.well-known/phip/resolve${keyResolveUrlA}`);
+      const xA = rKeyA.body
+        && rKeyA.body.attributes
+        && rKeyA.body.attributes["phip:keys"]
+        && rKeyA.body.attributes["phip:keys"].x;
+      if (!xA) {
+        test(
+          "topology+capability: signing key resolves and exposes phip:keys.x",
+          false,
+          `could not resolve ${sigA.key_id}`,
+        );
+      } else {
+        const rawPubA = Buffer.from(xA, "base64url");
+        const spkiA = Buffer.concat([Buffer.from("302a300506032b6570032100", "hex"), rawPubA]);
+        const pubKeyA = crypto.createPublicKey({ key: spkiA, format: "der", type: "spki" });
+        const verifiedA = crypto.verify(null, signedBytesA, pubKeyA, sigBytesA);
+        test("topology+capability: topology_signature verifies", verifiedA);
+      }
+    }
 
     // Path B: read_topology WITHOUT ?disclosure=topology → 403 INVALID_CAPABILITY.
     const rPathB = await request(

--- a/tests/conformance/run.js
+++ b/tests/conformance/run.js
@@ -1154,13 +1154,140 @@ async function main() {
         && rDesc.body.topology[0] && rDesc.body.topology[0].previous_hash === "genesis",
     );
 
-    // read_history token without ?disclosure=topology returns full history.
-    // (Bare GET history is already tested earlier; here we just confirm
-    // adding the param against a non-restricted object also yields topology.)
+    // ── 21b. Token-path probes against a restricted object ─────────────
+    // Up to this point §21 has exercised topology shape against a public
+    // object. The spec's gating rules — read_topology scope coverage,
+    // granted_to: "*" handling, INVALID_CAPABILITY for missing
+    // ?disclosure=topology, MISSING_CAPABILITY for absent token — only
+    // fire on restricted objects, so we create one here and exercise
+    // each path explicitly.
+    console.log(`  -- restricted-object token paths --`);
 
-    // Untokened request: still topology (object is public in our test run).
-    // But §11.5.6 grants this implicitly through normal /history access.
-    // No additional assertion — the first GET above covered it.
+    const TOPO_RESTRICTED_LOCAL = `units/topo-restricted-${RUN_ID}`;
+    const TOPO_RESTRICTED_PHIP = `phip://${AUTHORITY}/${NAMESPACE}/${TOPO_RESTRICTED_LOCAL}`;
+
+    const restrictedEvt0 = signEvent({
+      event_id: newEventId(),
+      phip_id: TOPO_RESTRICTED_PHIP,
+      type: "created",
+      timestamp: new Date().toISOString(),
+      actor: KEY_PHIP_ID,
+      previous_hash: "genesis",
+      payload: {
+        object_type: "design",
+        state: "design",
+        attributes: { "phip:access": { policy: "capability" } },
+      },
+    }, KEY_PHIP_ID);
+    await request("POST", OBJECTS(NAMESPACE), restrictedEvt0);
+
+    const restrictedEvt1 = signEvent({
+      event_id: newEventId(),
+      phip_id: TOPO_RESTRICTED_PHIP,
+      type: "state_transition",
+      timestamp: new Date().toISOString(),
+      actor: KEY_PHIP_ID,
+      previous_hash: hashEvent(restrictedEvt0),
+      payload: { from: "design", to: "qualified" },
+    }, KEY_PHIP_ID);
+    await request("POST", PUSH(NAMESPACE, TOPO_RESTRICTED_LOCAL), restrictedEvt1);
+
+    function mintTopoToken({ scope, granted_to, object_filter }) {
+      const t = {
+        phip_capability: "1.0",
+        token_id: newEventId(),
+        granted_by: KEY_PHIP_ID,
+        granted_to,
+        scope,
+        object_filter,
+        not_before: "2026-01-01T00:00:00Z",
+        expires: "2099-01-01T00:00:00Z",
+      };
+      const sig = crypto.sign(null, canonicalBytes(t), privateKey);
+      t.signature = {
+        algorithm: "Ed25519",
+        key_id: KEY_PHIP_ID,
+        value: sig.toString("base64url"),
+      };
+      return Buffer.from(JSON.stringify(t), "utf8").toString("base64url");
+    }
+
+    const topoStarToken = mintTopoToken({
+      scope: "read_topology",
+      granted_to: "*",
+      object_filter: TOPO_RESTRICTED_PHIP,
+    });
+
+    // Path A: read_topology + ?disclosure=topology → 200 with topology body.
+    const rPathA = await request(
+      "GET",
+      `/.well-known/phip/history/${NAMESPACE}/${TOPO_RESTRICTED_LOCAL}?disclosure=topology`,
+      null,
+      { Authorization: `PhIP-Capability ${topoStarToken}` },
+    );
+    test(
+      "topology+capability: read_topology '*' + ?disclosure=topology returns 200",
+      rPathA.status === 200,
+      `got ${rPathA.status}`,
+    );
+    test(
+      "topology+capability: response body is topology mode",
+      rPathA.body && rPathA.body.disclosure === "topology",
+    );
+
+    // Path B: read_topology WITHOUT ?disclosure=topology → 403 INVALID_CAPABILITY.
+    const rPathB = await request(
+      "GET",
+      `/.well-known/phip/history/${NAMESPACE}/${TOPO_RESTRICTED_LOCAL}`,
+      null,
+      { Authorization: `PhIP-Capability ${topoStarToken}` },
+    );
+    test(
+      "topology+capability: read_topology without ?disclosure returns 403",
+      rPathB.status === 403,
+      `got ${rPathB.status}`,
+    );
+    test(
+      "topology+capability: error code is INVALID_CAPABILITY",
+      rPathB.body && rPathB.body.error
+        && rPathB.body.error.code === "INVALID_CAPABILITY",
+    );
+
+    // Path C: no token + ?disclosure=topology on a capability-policy object
+    // → 403 MISSING_CAPABILITY (§11.5.2 step 3).
+    const rPathC = await request(
+      "GET",
+      `/.well-known/phip/history/${NAMESPACE}/${TOPO_RESTRICTED_LOCAL}?disclosure=topology`,
+    );
+    test(
+      "topology+capability: no token returns 403",
+      rPathC.status === 403,
+      `got ${rPathC.status}`,
+    );
+    test(
+      "topology+capability: error code is MISSING_CAPABILITY",
+      rPathC.body && rPathC.body.error
+        && rPathC.body.error.code === "MISSING_CAPABILITY",
+    );
+
+    // Path D: read_topology on GET state (no history endpoint) → 403
+    // INVALID_CAPABILITY (scope-insufficient per §11.5.2 step 5).
+    const rPathD = await request(
+      "GET",
+      RESOLVE(NAMESPACE, TOPO_RESTRICTED_LOCAL),
+      null,
+      { Authorization: `PhIP-Capability ${topoStarToken}` },
+    );
+    test(
+      "topology+capability: read_topology on GET state returns 403",
+      rPathD.status === 403,
+      `got ${rPathD.status}`,
+    );
+    test(
+      "topology+capability: GET state error code is INVALID_CAPABILITY",
+      rPathD.body && rPathD.body.error
+        && rPathD.body.error.code === "INVALID_CAPABILITY",
+    );
   }
 
   // ── summary ───────────────────────────────────────────────────────

--- a/tests/vectors/generate.js
+++ b/tests/vectors/generate.js
@@ -926,4 +926,250 @@ writeJson("bundle/cases.json", {
   bundles: [oneObjectBundle, multiObjectBundle, tamperedBundle],
 });
 
+// ─────────────────────────────────────────────────────────────────────
+// 11. Topology disclosure — Section 11.5.6
+// ─────────────────────────────────────────────────────────────────────
+//
+// A topology response exposes the chain shape of an object's event log
+// without payloads, actors, or per-event signatures. The whole envelope
+// (four canonical fields: disclosure, page_length, phip_id, topology)
+// is signed once by the resolver's authority key.
+//
+// Per §11.5.6.4 the topology_signature covers the JCS canonicalization
+// of an object containing EXACTLY {disclosure, page_length, phip_id,
+// topology} — verifiers ignore any other top-level fields the response
+// may carry.
+//
+// Per §11.5.6.5 topology is always returned in ascending chain order
+// (oldest first). The ?order parameter is ignored in topology mode.
+//
+// Cases:
+//   - valid-multi-event       : 3-event chain, signature + chain walk verify
+//   - valid-single-event      : genesis-only object
+//   - tampered-envelope       : phip_id mutated post-sign → signature rejects
+//   - tampered-chain-link     : entry[1].previous_hash != entry[0].event_hash
+//                               → walk rejects (signature still nominally
+//                               verifies against the tampered envelope when
+//                               re-signed; here we keep the original
+//                               signature, so signature ALSO rejects)
+//   - two-pages-stitchable    : two pages with a valid inter-page link
+
+const TOP_AUTHORITY = "acme.example";
+const TOP_RESOLVER_KEY_PHIP = `phip://${TOP_AUTHORITY}/keys/test-key-alice`;
+const TOP_OBJECT_PHIP = `phip://${TOP_AUTHORITY}/projects/widget-v3`;
+
+function topologyEntryFor(event) {
+  // Drop payload, actor, signature; expose only the five canonical fields.
+  return {
+    event_id: event.event_id,
+    type: event.type,
+    timestamp: event.timestamp,
+    previous_hash: event.previous_hash,
+    event_hash: hashEvent(event),
+  };
+}
+
+function signTopologyResponse({ phip_id, topology, key_id }) {
+  // §11.5.6.4: signature covers exactly {disclosure, page_length, phip_id, topology}.
+  // No other fields. JCS sorts keys lexically; the object literal below is
+  // for human readability — JCS produces identical bytes regardless of
+  // enumeration order.
+  const canonicalSigned = {
+    disclosure: "topology",
+    page_length: topology.length,
+    phip_id,
+    topology,
+  };
+  const sig = crypto.sign(null, canonicalBytes(canonicalSigned), getKey(key_id).privateKey);
+  return {
+    algorithm: "Ed25519",
+    key_id: TOP_RESOLVER_KEY_PHIP,
+    value: sig.toString("base64url"),
+  };
+}
+
+function buildTopologyResponse({ phip_id, topology, key_id, next_cursor = null }) {
+  return {
+    phip_id,
+    page_length: topology.length,
+    disclosure: "topology",
+    topology,
+    topology_signature: signTopologyResponse({ phip_id, topology, key_id }),
+    next_cursor,
+  };
+}
+
+// Build a 3-event chain: created → state_transition → attribute_update.
+const topEvt0 = signEvent(
+  {
+    event_id: "40000000-0000-4000-a000-000000000001",
+    phip_id: TOP_OBJECT_PHIP,
+    type: "created",
+    timestamp: "2026-01-15T09:00:00Z",
+    actor: TOP_RESOLVER_KEY_PHIP,
+    previous_hash: "genesis",
+    payload: { object_type: "design", state: "design" },
+  },
+  "test-key-alice",
+);
+const topEvt1 = signEvent(
+  {
+    event_id: "40000000-0000-4000-a000-000000000002",
+    phip_id: TOP_OBJECT_PHIP,
+    type: "state_transition",
+    timestamp: "2026-01-22T14:30:00Z",
+    actor: TOP_RESOLVER_KEY_PHIP,
+    previous_hash: hashEvent(topEvt0),
+    payload: { from: "design", to: "qualified" },
+  },
+  "test-key-alice",
+);
+const topEvt2 = signEvent(
+  {
+    event_id: "40000000-0000-4000-a000-000000000003",
+    phip_id: TOP_OBJECT_PHIP,
+    type: "attribute_update",
+    timestamp: "2026-02-01T10:00:00Z",
+    actor: TOP_RESOLVER_KEY_PHIP,
+    previous_hash: hashEvent(topEvt1),
+    payload: { namespace: "phip:mechanical", updates: { confidential: "redacted" } },
+  },
+  "test-key-alice",
+);
+
+const topologyCases = [];
+
+// Case 1: valid 3-event topology
+{
+  const topology = [topEvt0, topEvt1, topEvt2].map(topologyEntryFor);
+  topologyCases.push({
+    name: "valid-multi-event",
+    description:
+      "3-event chain (created → state_transition → attribute_update). " +
+      "Signature MUST verify against test-key-alice's public key over the " +
+      "JCS canonicalization of {disclosure, page_length, phip_id, topology}. " +
+      "Chain walk MUST succeed: entry[N].previous_hash == entry[N-1].event_hash.",
+    verifying_key_id: "test-key-alice",
+    response: buildTopologyResponse({
+      phip_id: TOP_OBJECT_PHIP,
+      topology,
+      key_id: "test-key-alice",
+    }),
+    expected: { signature_verifies: true, chain_walk_succeeds: true },
+  });
+}
+
+// Case 2: valid single-event (genesis-only)
+{
+  const topology = [topEvt0].map(topologyEntryFor);
+  topologyCases.push({
+    name: "valid-single-event",
+    description:
+      "Genesis-only object — topology has one entry whose previous_hash is " +
+      "the literal 'genesis'. Signature verifies; chain walk is trivially " +
+      "satisfied (no inter-entry comparisons).",
+    verifying_key_id: "test-key-alice",
+    response: buildTopologyResponse({
+      phip_id: TOP_OBJECT_PHIP,
+      topology,
+      key_id: "test-key-alice",
+    }),
+    expected: { signature_verifies: true, chain_walk_succeeds: true },
+  });
+}
+
+// Case 3: tampered envelope — phip_id mutated post-signing
+{
+  const topology = [topEvt0, topEvt1].map(topologyEntryFor);
+  const response = buildTopologyResponse({
+    phip_id: TOP_OBJECT_PHIP,
+    topology,
+    key_id: "test-key-alice",
+  });
+  // Mutate phip_id after signing — signature must fail.
+  response.phip_id = `phip://${TOP_AUTHORITY}/projects/widget-IMPOSTER`;
+  topologyCases.push({
+    name: "tampered-envelope",
+    description:
+      "phip_id mutated after the resolver signed the envelope. Verifiers " +
+      "reconstruct the canonical signed object from the (mutated) wire " +
+      "phip_id; the resulting JCS bytes differ from what the resolver " +
+      "signed, so the signature MUST fail.",
+    verifying_key_id: "test-key-alice",
+    response,
+    expected: { signature_verifies: false, chain_walk_succeeds: true },
+    notes:
+      "Chain walk still succeeds because the topology entries themselves " +
+      "are unmodified. The signature failure is the sole rejection signal.",
+  });
+}
+
+// Case 4: tampered chain link — entry[1].previous_hash points at the wrong event
+{
+  const topology = [topEvt0, topEvt1].map(topologyEntryFor);
+  // Mutate entry[1].previous_hash to a syntactically valid but wrong value.
+  topology[1].previous_hash =
+    "sha256:0000000000000000000000000000000000000000000000000000000000000000";
+  topologyCases.push({
+    name: "tampered-chain-link",
+    description:
+      "entry[1].previous_hash mutated to a syntactically valid but " +
+      "incorrect sha256 value. The topology is then re-signed by the " +
+      "resolver, so the signature itself verifies — but the chain walk " +
+      "MUST reject because entry[1].previous_hash != entry[0].event_hash.",
+    verifying_key_id: "test-key-alice",
+    response: buildTopologyResponse({
+      phip_id: TOP_OBJECT_PHIP,
+      topology,
+      key_id: "test-key-alice",
+    }),
+    expected: { signature_verifies: true, chain_walk_succeeds: false },
+  });
+}
+
+// Case 5: two pages with a valid inter-page link
+{
+  const page1Topology = [topEvt0, topEvt1].map(topologyEntryFor);
+  const page2Topology = [topEvt2].map(topologyEntryFor);
+  const page1 = buildTopologyResponse({
+    phip_id: TOP_OBJECT_PHIP,
+    topology: page1Topology,
+    key_id: "test-key-alice",
+    next_cursor: "sha256:" + sha256Hex(canonicalBytes(topEvt1)),
+  });
+  const page2 = buildTopologyResponse({
+    phip_id: TOP_OBJECT_PHIP,
+    topology: page2Topology,
+    key_id: "test-key-alice",
+    next_cursor: null,
+  });
+  topologyCases.push({
+    name: "two-pages-stitchable",
+    description:
+      "Two pages of topology. Each page's signature MUST verify " +
+      "independently. The inter-page link is verified by checking " +
+      "page2.topology[0].previous_hash == page1.topology[-1].event_hash.",
+    verifying_key_id: "test-key-alice",
+    pages: [page1, page2],
+    expected: {
+      page_signatures_verify: [true, true],
+      inter_page_link_holds: true,
+    },
+  });
+}
+
+writeJson("topology/cases.json", {
+  description:
+    "Topology disclosure test vectors (Section 11.5.6). Each case shows " +
+    "a topology response document, the key whose public bytes verify the " +
+    "topology_signature, and the expected verification outcomes. " +
+    "Implementations MUST agree on signature verification and on the " +
+    "chain-walk check (entry[N].previous_hash == entry[N-1].event_hash). " +
+    "The signed object is the four-field canonical envelope " +
+    "{disclosure, page_length, phip_id, topology} — verifiers MUST " +
+    "construct that object verbatim, JCS-canonicalize, and verify " +
+    "against the resolver's public key per §11.5.6.4.",
+  cases: topologyCases,
+});
+
 console.log("\nall vectors written.");

--- a/tests/vectors/self-check.js
+++ b/tests/vectors/self-check.js
@@ -380,6 +380,13 @@ console.log("\n[topology]");
           && sigResults[1] === c.expected.page_signatures_verify[1],
         `topology ${c.name} per-page signatures match expected`,
       );
+      // In-page chain walks (each page independently honors the
+      // entry[N].previous_hash == entry[N-1].event_hash rule).
+      const perPageWalks = c.pages.map((p) => walkChain(p.topology));
+      assert(
+        perPageWalks.every((ok) => ok === true),
+        `topology ${c.name} in-page chain walks succeed on every page`,
+      );
       const interOk =
         c.pages[1].topology[0].previous_hash
         === c.pages[0].topology[c.pages[0].topology.length - 1].event_hash;

--- a/tests/vectors/self-check.js
+++ b/tests/vectors/self-check.js
@@ -335,5 +335,72 @@ console.log("\n[bundle]");
   }
 }
 
+// ── Topology disclosure — Section 11.5.6 ───────────────────────────
+console.log("\n[topology]");
+{
+  const KEYS = {
+    "test-key-alice": loadKey({
+      id: "test-key-alice",
+      private_pkcs8_b64: "MC4CAQAwBQYDK2VwBCIEILYVuTR2efrX2+iRiMd6EmrgZNMaFhxPi8HpoS/N7PUh",
+      public_raw_b64url: "-PMJVmvQQLw38uBOg3w4CXVk6CkadzUozxMUTzq96Ws",
+    }),
+  };
+
+  function verifyTopologySignature(response, keyId) {
+    // §11.5.6.4: construct {disclosure, page_length, phip_id, topology}
+    // from the response verbatim and JCS-canonicalize. Ignore all other
+    // top-level fields.
+    const canonicalSigned = {
+      disclosure: response.disclosure,
+      page_length: response.page_length,
+      phip_id: response.phip_id,
+      topology: response.topology,
+    };
+    const bytes = Buffer.from(canonicalize(canonicalSigned), "utf8");
+    const sigBytes = Buffer.from(response.topology_signature.value, "base64url");
+    return crypto.verify(null, bytes, KEYS[keyId].publicKey, sigBytes);
+  }
+
+  function walkChain(topology) {
+    // entry[N].previous_hash MUST equal entry[N-1].event_hash for N > 0.
+    for (let i = 1; i < topology.length; i++) {
+      if (topology[i].previous_hash !== topology[i - 1].event_hash) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  const { cases } = load("topology/cases.json");
+  for (const c of cases) {
+    if (c.pages) {
+      const sigResults = c.pages.map((p) => verifyTopologySignature(p, c.verifying_key_id));
+      assert(
+        sigResults[0] === c.expected.page_signatures_verify[0]
+          && sigResults[1] === c.expected.page_signatures_verify[1],
+        `topology ${c.name} per-page signatures match expected`,
+      );
+      const interOk =
+        c.pages[1].topology[0].previous_hash
+        === c.pages[0].topology[c.pages[0].topology.length - 1].event_hash;
+      assert(
+        interOk === c.expected.inter_page_link_holds,
+        `topology ${c.name} inter-page link holds`,
+      );
+    } else {
+      const sigOk = verifyTopologySignature(c.response, c.verifying_key_id);
+      assert(
+        sigOk === c.expected.signature_verifies,
+        `topology ${c.name} signature ${c.expected.signature_verifies ? "verifies" : "rejects"}`,
+      );
+      const walkOk = walkChain(c.response.topology);
+      assert(
+        walkOk === c.expected.chain_walk_succeeds,
+        `topology ${c.name} chain walk ${c.expected.chain_walk_succeeds ? "succeeds" : "rejects"}`,
+      );
+    }
+  }
+}
+
 console.log(`\n${pass} passed, ${fail} failed`);
 process.exit(fail === 0 ? 0 : 1);

--- a/tests/vectors/topology/cases.json
+++ b/tests/vectors/topology/cases.json
@@ -1,0 +1,211 @@
+{
+  "description": "Topology disclosure test vectors (Section 11.5.6). Each case shows a topology response document, the key whose public bytes verify the topology_signature, and the expected verification outcomes. Implementations MUST agree on signature verification and on the chain-walk check (entry[N].previous_hash == entry[N-1].event_hash). The signed object is the four-field canonical envelope {disclosure, page_length, phip_id, topology} — verifiers MUST construct that object verbatim, JCS-canonicalize, and verify against the resolver's public key per §11.5.6.4.",
+  "cases": [
+    {
+      "name": "valid-multi-event",
+      "description": "3-event chain (created → state_transition → attribute_update). Signature MUST verify against test-key-alice's public key over the JCS canonicalization of {disclosure, page_length, phip_id, topology}. Chain walk MUST succeed: entry[N].previous_hash == entry[N-1].event_hash.",
+      "verifying_key_id": "test-key-alice",
+      "response": {
+        "phip_id": "phip://acme.example/projects/widget-v3",
+        "page_length": 3,
+        "disclosure": "topology",
+        "topology": [
+          {
+            "event_id": "40000000-0000-4000-a000-000000000001",
+            "type": "created",
+            "timestamp": "2026-01-15T09:00:00Z",
+            "previous_hash": "genesis",
+            "event_hash": "sha256:cff0bf391acbb147e95e6f70fa83536dc702736f7ad908553362ee77d2227b91"
+          },
+          {
+            "event_id": "40000000-0000-4000-a000-000000000002",
+            "type": "state_transition",
+            "timestamp": "2026-01-22T14:30:00Z",
+            "previous_hash": "sha256:cff0bf391acbb147e95e6f70fa83536dc702736f7ad908553362ee77d2227b91",
+            "event_hash": "sha256:efb7eedf9be5c7fa617335e206097e04a229974663261ebfb1b635c5ea7b1cb5"
+          },
+          {
+            "event_id": "40000000-0000-4000-a000-000000000003",
+            "type": "attribute_update",
+            "timestamp": "2026-02-01T10:00:00Z",
+            "previous_hash": "sha256:efb7eedf9be5c7fa617335e206097e04a229974663261ebfb1b635c5ea7b1cb5",
+            "event_hash": "sha256:aa6152d7ec0b671d06f89421e520431cef2dc1865cdd3a81163427e0257fd969"
+          }
+        ],
+        "topology_signature": {
+          "algorithm": "Ed25519",
+          "key_id": "phip://acme.example/keys/test-key-alice",
+          "value": "t3AmEfRJwjAbTZNd64IL5MsqAXZdrOdDx6qtCsS86OMDNMmVWrlh1foXQzCiamuujzlznZJYyXwQnrmmQQsFCw"
+        },
+        "next_cursor": null
+      },
+      "expected": {
+        "signature_verifies": true,
+        "chain_walk_succeeds": true
+      }
+    },
+    {
+      "name": "valid-single-event",
+      "description": "Genesis-only object — topology has one entry whose previous_hash is the literal 'genesis'. Signature verifies; chain walk is trivially satisfied (no inter-entry comparisons).",
+      "verifying_key_id": "test-key-alice",
+      "response": {
+        "phip_id": "phip://acme.example/projects/widget-v3",
+        "page_length": 1,
+        "disclosure": "topology",
+        "topology": [
+          {
+            "event_id": "40000000-0000-4000-a000-000000000001",
+            "type": "created",
+            "timestamp": "2026-01-15T09:00:00Z",
+            "previous_hash": "genesis",
+            "event_hash": "sha256:cff0bf391acbb147e95e6f70fa83536dc702736f7ad908553362ee77d2227b91"
+          }
+        ],
+        "topology_signature": {
+          "algorithm": "Ed25519",
+          "key_id": "phip://acme.example/keys/test-key-alice",
+          "value": "D-bSiRwTW2XpKzAeBGzbQxXVm-9a1Rs2Ar5QiuyOVxyBgRijXZeDDasRL1tnwMOa8oG3q8l-z02quqFnkOniCQ"
+        },
+        "next_cursor": null
+      },
+      "expected": {
+        "signature_verifies": true,
+        "chain_walk_succeeds": true
+      }
+    },
+    {
+      "name": "tampered-envelope",
+      "description": "phip_id mutated after the resolver signed the envelope. Verifiers reconstruct the canonical signed object from the (mutated) wire phip_id; the resulting JCS bytes differ from what the resolver signed, so the signature MUST fail.",
+      "verifying_key_id": "test-key-alice",
+      "response": {
+        "phip_id": "phip://acme.example/projects/widget-IMPOSTER",
+        "page_length": 2,
+        "disclosure": "topology",
+        "topology": [
+          {
+            "event_id": "40000000-0000-4000-a000-000000000001",
+            "type": "created",
+            "timestamp": "2026-01-15T09:00:00Z",
+            "previous_hash": "genesis",
+            "event_hash": "sha256:cff0bf391acbb147e95e6f70fa83536dc702736f7ad908553362ee77d2227b91"
+          },
+          {
+            "event_id": "40000000-0000-4000-a000-000000000002",
+            "type": "state_transition",
+            "timestamp": "2026-01-22T14:30:00Z",
+            "previous_hash": "sha256:cff0bf391acbb147e95e6f70fa83536dc702736f7ad908553362ee77d2227b91",
+            "event_hash": "sha256:efb7eedf9be5c7fa617335e206097e04a229974663261ebfb1b635c5ea7b1cb5"
+          }
+        ],
+        "topology_signature": {
+          "algorithm": "Ed25519",
+          "key_id": "phip://acme.example/keys/test-key-alice",
+          "value": "P2jOriGX61xcbzwZbRnLt6FDW6WY_tHkCDCHQsIg2U3_3t-7s9t_OcUxP1Aq0b4iZlJJFW1HaODv85dVqyjzAw"
+        },
+        "next_cursor": null
+      },
+      "expected": {
+        "signature_verifies": false,
+        "chain_walk_succeeds": true
+      },
+      "notes": "Chain walk still succeeds because the topology entries themselves are unmodified. The signature failure is the sole rejection signal."
+    },
+    {
+      "name": "tampered-chain-link",
+      "description": "entry[1].previous_hash mutated to a syntactically valid but incorrect sha256 value. The topology is then re-signed by the resolver, so the signature itself verifies — but the chain walk MUST reject because entry[1].previous_hash != entry[0].event_hash.",
+      "verifying_key_id": "test-key-alice",
+      "response": {
+        "phip_id": "phip://acme.example/projects/widget-v3",
+        "page_length": 2,
+        "disclosure": "topology",
+        "topology": [
+          {
+            "event_id": "40000000-0000-4000-a000-000000000001",
+            "type": "created",
+            "timestamp": "2026-01-15T09:00:00Z",
+            "previous_hash": "genesis",
+            "event_hash": "sha256:cff0bf391acbb147e95e6f70fa83536dc702736f7ad908553362ee77d2227b91"
+          },
+          {
+            "event_id": "40000000-0000-4000-a000-000000000002",
+            "type": "state_transition",
+            "timestamp": "2026-01-22T14:30:00Z",
+            "previous_hash": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+            "event_hash": "sha256:efb7eedf9be5c7fa617335e206097e04a229974663261ebfb1b635c5ea7b1cb5"
+          }
+        ],
+        "topology_signature": {
+          "algorithm": "Ed25519",
+          "key_id": "phip://acme.example/keys/test-key-alice",
+          "value": "9HRURcdgnZTmWew3lfOcJNA-q3QK3ndqMtDclzftot7alUlP6wEjlDAeewOmYQt2IvY435qVvo0XQ-PHqPzxBg"
+        },
+        "next_cursor": null
+      },
+      "expected": {
+        "signature_verifies": true,
+        "chain_walk_succeeds": false
+      }
+    },
+    {
+      "name": "two-pages-stitchable",
+      "description": "Two pages of topology. Each page's signature MUST verify independently. The inter-page link is verified by checking page2.topology[0].previous_hash == page1.topology[-1].event_hash.",
+      "verifying_key_id": "test-key-alice",
+      "pages": [
+        {
+          "phip_id": "phip://acme.example/projects/widget-v3",
+          "page_length": 2,
+          "disclosure": "topology",
+          "topology": [
+            {
+              "event_id": "40000000-0000-4000-a000-000000000001",
+              "type": "created",
+              "timestamp": "2026-01-15T09:00:00Z",
+              "previous_hash": "genesis",
+              "event_hash": "sha256:cff0bf391acbb147e95e6f70fa83536dc702736f7ad908553362ee77d2227b91"
+            },
+            {
+              "event_id": "40000000-0000-4000-a000-000000000002",
+              "type": "state_transition",
+              "timestamp": "2026-01-22T14:30:00Z",
+              "previous_hash": "sha256:cff0bf391acbb147e95e6f70fa83536dc702736f7ad908553362ee77d2227b91",
+              "event_hash": "sha256:efb7eedf9be5c7fa617335e206097e04a229974663261ebfb1b635c5ea7b1cb5"
+            }
+          ],
+          "topology_signature": {
+            "algorithm": "Ed25519",
+            "key_id": "phip://acme.example/keys/test-key-alice",
+            "value": "P2jOriGX61xcbzwZbRnLt6FDW6WY_tHkCDCHQsIg2U3_3t-7s9t_OcUxP1Aq0b4iZlJJFW1HaODv85dVqyjzAw"
+          },
+          "next_cursor": "sha256:efb7eedf9be5c7fa617335e206097e04a229974663261ebfb1b635c5ea7b1cb5"
+        },
+        {
+          "phip_id": "phip://acme.example/projects/widget-v3",
+          "page_length": 1,
+          "disclosure": "topology",
+          "topology": [
+            {
+              "event_id": "40000000-0000-4000-a000-000000000003",
+              "type": "attribute_update",
+              "timestamp": "2026-02-01T10:00:00Z",
+              "previous_hash": "sha256:efb7eedf9be5c7fa617335e206097e04a229974663261ebfb1b635c5ea7b1cb5",
+              "event_hash": "sha256:aa6152d7ec0b671d06f89421e520431cef2dc1865cdd3a81163427e0257fd969"
+            }
+          ],
+          "topology_signature": {
+            "algorithm": "Ed25519",
+            "key_id": "phip://acme.example/keys/test-key-alice",
+            "value": "RfZXX-vNQNLi5lPDccAUuVINS7Vp9GzSz1XE5_uGnrMCHZ_0OenC57aU8L2VFCxpTT-mE2BePyZUkrWEey1QAA"
+          },
+          "next_cursor": null
+        }
+      ],
+      "expected": {
+        "page_signatures_verify": [
+          true,
+          true
+        ],
+        "inter_page_link_holds": true
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Motivation

`read_state` and `read_history` are the only read scopes on history. There is no middle ground for *"this object exists, has chain shape X, and was last touched at T"* without exposing payloads, actors, or per-event signatures.

This gap surfaces in the **private design with publicly listed instances** pattern: a public `assembly` object holds an `instance_of` relation pointing at a private `design`, and external readers want to confirm the design exists and is under active stewardship without seeing its contents. Today `read_state` hides too little (whole projection) and `read_history` hides too much (whole event payloads).

Discovered while implementing a read-only PhIP resolver for the [asap-pcb-dfm](https://github.com/vmc-7645/asap-pcb-dfm/pull/3) pilot.

## Proposal

Add an **optional** topology disclosure mode. Resolvers MAY support it; absence implies no support.

### Spec
- New §11.5.6 *Topology Disclosure (Optional)*, with subsections covering scope and limits (11.5.6.1), request shape (11.5.6.2), response shape (11.5.6.3), signature + chain verification (11.5.6.4), pagination + ascending-order requirement (11.5.6.5), cross-authority composition (11.5.6.6), what topology does NOT protect (11.5.6.7), and reference material pointers (11.5.6.8).
- New `read_topology` capability-token scope (§11.3.2). Grants **only** topology disclosure — not GET state, default GET history, QUERY, or any PUSH.
- `granted_to` accepts the literal string `"*"` (§11.3.1) — presenter-anonymous grant for low-leakage scopes; auditors flag combinations with `object_filter: "*"`.
- `/meta.disclosures` array advertises topology support (§12.7).
- §11.5.2 resolution order routes `read_topology` through topology mode; §11.5.4 explicitly exempts topology mode from the "no chain-head side channels" rule (topology is the canonical disclosure path).
- Error codes mapped to existing §12.6 codes — no new codes introduced:
  - Resolver doesn't advertise topology → `OPERATION_NOT_SUPPORTED` (405)
  - `read_topology` token without `?disclosure=topology` → `INVALID_CAPABILITY` (403, "scope insufficient")
  - No token on a restricted object → `MISSING_CAPABILITY` (403)
- Appendix A.2 gains entry A42 (Medium) — first post-v0.1 open item, now resolved by this PR.

### Wire format

Request:
```
GET https://{authority}/.well-known/phip/history/{ns}/{id}?disclosure=topology
Authorization: PhIP-Capability <token>
```

Response envelope:
```json
{
  "phip_id": "phip://acme.example/projects/widget-v3",
  "page_length": 3,
  "disclosure": "topology",
  "topology": [
    {
      "event_id": "evt-...",
      "type": "created",
      "timestamp": "2026-01-15T09:00:00Z",
      "previous_hash": "genesis",
      "event_hash": "sha256:..."
    },
    ...
  ],
  "topology_signature": { "algorithm": "Ed25519", "key_id": "...", "value": "..." },
  "next_cursor": null
}
```

Each entry MUST contain exactly five fields: `event_id`, `type`, `timestamp`, `previous_hash`, `event_hash`. The `topology_signature` covers JCS(`{disclosure, page_length, phip_id, topology}`) — the four canonical envelope fields — signed by a key resource of the serving authority. Topology is always returned in ascending chain order; `?order=desc` is ignored. Cache-Control MUST be `no-store` (or `private, max-age=0`).

Consumers can verify chain continuity without payloads: `entry[N].previous_hash == entry[N-1].event_hash` within a page; `page[K+1].topology[0].previous_hash == page[K].topology[-1].event_hash` across pages.

### Schemas

- `schemas/capability-token.json` → 1.1 — `scope` enum adds `read_topology`; `granted_to` is now `oneOf [phipUri, "*"]`. MINOR per VERSIONING.md (additive).
- `schemas/meta.json` → 1.1 — adds optional `disclosures` field (array of strings, enum `["topology"]`).
- `schemas/topology-response.json` — new at 1.0, defines the full response document.

## Backwards compatibility

Purely additive. Existing tokens, existing GET-history responses, and existing test vectors are unaffected.

## Test surface (CONTRIBUTING.md checklist)

- `tests/vectors/topology/cases.json` — 5 fixtures:
  - `valid-multi-event` — 3-event chain, signature + walk both pass
  - `valid-single-event` — genesis-only, walk trivially holds
  - `tampered-envelope` — `phip_id` mutated post-sign → signature rejects
  - `tampered-chain-link` — wrong `previous_hash` → chain walk rejects
  - `two-pages-stitchable` — two pages with valid inter-page link
- `tests/vectors/generate.js` extended with a topology section using the existing `signEvent`/`hashEvent`/`canonicalBytes` helpers. Deterministic byte output.
- `tests/vectors/self-check.js` runs 10 new assertions; suite total **200/200 pass**.
- `tests/conformance/run.js` §21 — opt-in probe (skipped when `/meta.disclosures` lacks `"topology"`). Covers:
  - Public-object shape: 200, Cache-Control, envelope marker, phip_id match, page_length consistency, five canonical entry fields, genesis-first, chain walk, signature shape + verification against resolved key, `?order=desc` ignored
  - Restricted-object token paths (Paths A–D): `read_topology "*"` token + disclosure → 200 with full shape/sig/walk re-checks; same token without disclosure → 403 `INVALID_CAPABILITY`; no token → 403 `MISSING_CAPABILITY`; same token on GET state → 403 `INVALID_CAPABILITY`
- `tests/conformance/README.md` — section table updated through §21.

## Files

| File | Change |
|---|---|
| `spec/phip-core.md` | New §11.5.6 (eight subsections); edits to §11.3.1, §11.3.2, §11.5.1, §11.5.2, §11.5.4; Appendix A.2 entry A42 |
| `spec/CHANGELOG.md` | `[Unreleased]` block with Added / Changed / Design notes / Order normative / Reference material subsections |
| `schemas/capability-token.json` | 1.0 → 1.1 (additive enum value + type alternative for `granted_to`) |
| `schemas/meta.json` | 1.0 → 1.1 (new optional `disclosures` field) |
| `schemas/topology-response.json` | New schema at 1.0 |
| `tests/vectors/generate.js` | Topology generator section |
| `tests/vectors/topology/cases.json` | 5 generated fixtures |
| `tests/vectors/self-check.js` | Topology verification block (10 new assertions) |
| `tests/conformance/run.js` | §21 + §21b (token paths) |
| `tests/conformance/README.md` | Section table refreshed through §21 |

## Review history

Eight self-review rounds while developing this PR — each pass tightened normative wording, fixed cryptographic-attestation defects (envelope signing, chain-walk verification, `event_hash` per entry), aligned error codes with §12.6, added missing CONTRIBUTING surface, and resolved verbal contradictions between §11.5.4 (no side channels) and §11.5.6 (topology IS the canonical chain-head disclosure). Commit history shows the trail; happy to squash on merge.

## Open for reviewer judgement

- **Naming**: "topology" vs. "skeleton" vs. "outline". Picked "topology" because a hash chain literally is a directed graph and the disclosure exposes its structure without node contents. Open to a bikeshed.
- **Query-param vs. separate endpoint**: `?disclosure=topology` keeps everything under the existing `/history/` URL surface; alternative would be `/topology/{ns}/{id}`. Param is lighter; endpoint is more discoverable in `/meta.supported_operations`.
- **`granted_to: "*"` sentinel**: minimal-surface choice over alternatives like a new `topology_public` access policy or a separate `granted_to_anyone` field. Schema oneOf covers it cleanly but constrains future extensions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
