### PR TITLE
conformance: PHIP_WRITE_TOKEN env var support

### DIFF
--- a/tests/conformance/README.md
+++ b/tests/conformance/README.md
@@ -38,6 +38,21 @@ phip-conformance http://127.0.0.1:8080 --authority acme.example
 * `--namespace` — the namespace to create objects under. Defaults to
   `conformance`.
 
+### Running against token-protected deployments
+
+Resolvers configured with a write token (e.g. `phip-server`'s
+`PHIP_WRITE_TOKEN`) reject every write without `Authorization: Bearer
+<token>`. Pass the same value via the `PHIP_WRITE_TOKEN` env var and the
+suite will inject it on every POST/PUT/PATCH/DELETE:
+
+```
+PHIP_WRITE_TOKEN=… phip-conformance https://resolver.example --authority resolver.example
+```
+
+The §18 capability-token probes use their own `Authorization` headers and
+take precedence over the bearer — they continue to exercise the
+`phip:access` enforcement path even when a write token is set.
+
 Each run generates a fresh 8-character run-id and suffixes every object id
 with it, so the suite can be executed repeatedly against the same server
 without CREATE collisions.

--- a/tests/conformance/README.md
+++ b/tests/conformance/README.md
@@ -53,6 +53,13 @@ The §18 capability-token probes use their own `Authorization` headers and
 take precedence over the bearer — they continue to exercise the
 `phip:access` enforcement path even when a write token is set.
 
+> **Security note**: passing the token on the command line makes it
+> visible in `ps auxe` to any local user on the same machine. For
+> sensitive deployments, write it to a file with restrictive
+> permissions and `export PHIP_WRITE_TOKEN=$(<token.txt)` before
+> running the suite, or set it via your shell profile / direnv with
+> `chmod 600` on the source file.
+
 Each run generates a fresh 8-character run-id and suffixes every object id
 with it, so the suite can be executed repeatedly against the same server
 without CREATE collisions.

--- a/tests/conformance/run.js
+++ b/tests/conformance/run.js
@@ -113,17 +113,26 @@ function newEventId() {
 
 // ── HTTP client ──────────────────────────────────────────────────────
 
+// Resolvers configured with PHIP_WRITE_TOKEN require a bearer on every
+// write. Pull the token from the same env var so this suite can run
+// against deployments that aren't open writes. Suite-managed Authorization
+// (e.g. the §18 capability tokens) takes precedence — those overrides
+// flow through `extraHeaders`.
+const WRITE_TOKEN = process.env.PHIP_WRITE_TOKEN || null;
+const _isWrite = (m) => m === "POST" || m === "PUT" || m === "PATCH" || m === "DELETE";
+
 function request(method, relPath, body, extraHeaders) {
   return new Promise((resolve, reject) => {
     const url = new URL(BASE_URL + relPath);
     const payload = body ? Buffer.from(JSON.stringify(body), "utf8") : null;
     const lib = url.protocol === "https:" ? https : http;
-    const headers = Object.assign(
-      payload
-        ? { "Content-Type": "application/json", "Content-Length": payload.length }
-        : {},
-      extraHeaders || {},
-    );
+    const baseHeaders = payload
+      ? { "Content-Type": "application/json", "Content-Length": payload.length }
+      : {};
+    if (WRITE_TOKEN && _isWrite(method) && !(extraHeaders && extraHeaders.Authorization)) {
+      baseHeaders["Authorization"] = `Bearer ${WRITE_TOKEN}`;
+    }
+    const headers = Object.assign(baseHeaders, extraHeaders || {});
     const opts = {
       hostname: url.hostname,
       port: url.port || (url.protocol === "https:" ? 443 : 80),

--- a/tests/conformance/run.js
+++ b/tests/conformance/run.js
@@ -121,6 +121,14 @@ function newEventId() {
 const WRITE_TOKEN = process.env.PHIP_WRITE_TOKEN || null;
 const _isWrite = (m) => m === "POST" || m === "PUT" || m === "PATCH" || m === "DELETE";
 
+function _hasAuthHeader(extra) {
+  if (!extra) return false;
+  // HTTP headers are case-insensitive; JS object keys aren't. Probe
+  // for any casing of "authorization" so a suite-managed override
+  // (lowercase or mixed-case) isn't shadowed by our bearer injection.
+  return Object.keys(extra).some((k) => k.toLowerCase() === "authorization");
+}
+
 function request(method, relPath, body, extraHeaders) {
   return new Promise((resolve, reject) => {
     const url = new URL(BASE_URL + relPath);
@@ -129,7 +137,7 @@ function request(method, relPath, body, extraHeaders) {
     const baseHeaders = payload
       ? { "Content-Type": "application/json", "Content-Length": payload.length }
       : {};
-    if (WRITE_TOKEN && _isWrite(method) && !(extraHeaders && extraHeaders.Authorization)) {
+    if (WRITE_TOKEN && _isWrite(method) && !_hasAuthHeader(extraHeaders)) {
       baseHeaders["Authorization"] = `Bearer ${WRITE_TOKEN}`;
     }
     const headers = Object.assign(baseHeaders, extraHeaders || {});


### PR DESCRIPTION
Resolvers like [phip-server](https://github.com/mfgs-us/phip-server) can be configured with a write token (env `PHIP_WRITE_TOKEN`) that requires every CREATE / PUSH / batch / blob upload to carry `Authorization: Bearer <token>`. Before this change, running the conformance suite against such a deployment cascade-failed at §1 because the bootstrap CREATE returned 401, leaving the rest of the suite unable to reach any subsequent section.

Concrete motivating case: ran the suite against a real Tailscale-deployed phip-server. The single line \`await request(\"POST\", OBJECTS(NAMESPACE), bootstrapEvent)\` at §1 returned 401, every subsequent section then failed downstream because the bootstrap actor didn't exist.

## What this changes

\`tests/conformance/run.js\` now reads \`PHIP_WRITE_TOKEN\` from the environment and, when set, injects \`Authorization: Bearer <token>\` on the four write methods (POST/PUT/PATCH/DELETE):

\`\`\`
PHIP_WRITE_TOKEN=… phip-conformance https://resolver.example --authority resolver.example
\`\`\`

Suite-managed \`Authorization\` headers (the §18 capability-token probes that pass \`{Authorization: \"PhIP-Capability …\"}\` via \`extraHeaders\`) take precedence — they continue to exercise the \`MISSING_CAPABILITY\`/\`INVALID_CAPABILITY\` paths even when the write-token env is set. Verified that §18 still passes with the env var set against a token-protected deployment.

## Test plan

- [x] Conformance suite against an open-write resolver still works (no env var → no Authorization header → behavior unchanged)
- [x] Conformance suite against a token-protected resolver passes 97/97 with the env var set
- [x] §18 capability probes still exercise both the \"missing\" and \"forged\" paths (the bearer never shadows the suite's per-request Authorization)

🤖 Generated with [Claude Code](https://claude.com/claude-code)