### PR TITLE
spec §11.5.6.5: clarify ?order=desc on topology is silent-ignore (not reject)

### DIFF
--- a/spec/CHANGELOG.md
+++ b/spec/CHANGELOG.md
@@ -57,8 +57,10 @@ All notable changes to the PhIP specification will be documented in this file.
 Topology disclosure MUST return events in **ascending chain order**
 (genesis at index 0 of the first page). The `?order` query parameter
 from §12.2.1 is ignored under `?disclosure=topology`; resolvers MUST
-NOT honor `?order=desc` for a topology request. This is a hard
-requirement so the §11.5.6.4 chain-walk rule
+silently ignore `?order=desc` and serve the canonical ascending
+response. Resolvers MUST NOT reject the request (e.g. with `400
+INVALID_QUERY`) on the basis of an incompatible `?order` value. This
+is a hard requirement so the §11.5.6.4 chain-walk rule
 (`entry[N].previous_hash == entry[N-1].event_hash`) applies uniformly
 across implementations. Full GET history continues to honor `?order`
 unchanged.

--- a/spec/phip-core.md
+++ b/spec/phip-core.md
@@ -2460,7 +2460,12 @@ the stitched chain is contiguous.
 Topology mode MUST return events in ascending chain order — oldest
 first, genesis at index 0 of the first page. The `?order` query
 parameter from §12.2.1 is ignored in topology mode; resolvers MUST
-NOT honor `?order=desc` for a `?disclosure=topology` request.
+silently ignore `?order=desc` for a `?disclosure=topology` request
+and serve the canonical ascending response. Resolvers MUST NOT reject
+the request (e.g. with `400 INVALID_QUERY`) on the basis of an
+incompatible `?order` value — the parameter is honored only outside
+topology mode.
+
 Ascending order is mandatory so the §11.5.6.4 chain-walk check
 (`entry[N].previous_hash == entry[N-1].event_hash`) applies
 uniformly; a descending topology would invert the check, requiring


### PR DESCRIPTION
The current §11.5.6.5 wording leaves room for interpretation:

> The \`?order\` query parameter from §12.2.1 is ignored in topology mode; resolvers MUST NOT honor \`?order=desc\` for a \`?disclosure=topology\` request.

\"MUST NOT honor\" reads as either:

- (A) **silently ignore** the parameter, serve the canonical ascending response (200 OK)
- (B) **reject** the request with 400 \`INVALID_QUERY\` since the parameter is incompatible

The conformance suite asserts (A) — it expects a 200 with ascending data when it sends \`?order=desc\`. A naive resolver implementation (one in the wild) initially shipped (B) and only converged on (A) after the suite caught the divergence.

## What this PR changes

Mandates (A) explicitly: resolvers **MUST silently ignore** \`?order=desc\` under \`?disclosure=topology\` and serve the canonical ascending response. Adds an explicit prohibition on rejecting the request (\"MUST NOT reject … on the basis of an incompatible \`?order\` value\") so there's no daylight for (B).

The substantive rule — ascending order is mandatory because of the chain-walk verification in §11.5.6.4 — is unchanged.

## Diff

- \`spec/phip-core.md\` §11.5.6.5: replace \"MUST NOT honor\" with explicit \"MUST silently ignore … MUST NOT reject\"
- \`spec/CHANGELOG.md\` topology normative note: same clarification

🤖 Generated with [Claude Code](https://claude.com/claude-code)